### PR TITLE
Fix bug in launching confirmation dialogs

### DIFF
--- a/frontend/app/src/doc-mgr/ConfirmationDialog.vue
+++ b/frontend/app/src/doc-mgr/ConfirmationDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="confirmIngest" max-width="500px">
+    <v-dialog v-model="active" max-width="500px">
         <v-card>
             <v-card-title class="text-h5">
                 <slot></slot>


### PR DESCRIPTION
Fixed bug with launching confirmation dialogs.

The confirmation dialog was not launching because the wrong model name was used. 