### PR TITLE
Use random number salt even on internal passwords

### DIFF
--- a/quick_fill_secrets.sh
+++ b/quick_fill_secrets.sh
@@ -4,17 +4,17 @@ export $(grep -v '^#' quick_fill.secrets.env | xargs -d '\n')
 
 # Auto-populate passwords that will never leave the local Docker environment.
 if [ -z "$MINIO_ROOT_PASSWORD" ]; then
-    export MINIO_ROOT_PASSWORD=miniopass_123
+    export MINIO_ROOT_PASSWORD=minio_$(gpg --gen-random --armor 1 16)
 fi
 if [ -z "$BACKEND_MINIO_USER_PASSWORD" ]; then
-    export BACKEND_MINIO_USER_PASSWORD=backendpass_123
+    export BACKEND_MINIO_USER_PASSWORD=backend_minio_$(gpg --gen-random --armor 1 16)
 fi
 
 if [ -z "$POSTGRES_PASSWORD" ]; then
-    export POSTGRES_PASSWORD=postgrespass
+    export POSTGRES_PASSWORD="postgres_$(gpg --gen-random --armor 1 16)"
 fi
 if [ -z "$BACKEND_POSTGRES_USER_PASSWORD" ]; then
-    export BACKEND_POSTGRES_USER_PASSWORD=langchainpass
+    export BACKEND_POSTGRES_USER_PASSWORD="backend_postgres_$(gpg --gen-random --armor 1 16)"
 fi
 
 # Generate the services' .secrets.env


### PR DESCRIPTION
Use a random number generator from gpg to salt the passwords that stay internal to the local Docker cluster. This makes the various local clusters have different passwords. We want to apply a learning from old WiFi routers.