### PR TITLE
Cleaner build and start

### DIFF
--- a/backend/docker/.dockerignore
+++ b/backend/docker/.dockerignore
@@ -1,5 +1,5 @@
 
-build_image.sh
+build_images.sh
 
 Dockerfile
 *.Dockerfile

--- a/display_processes.sh
+++ b/display_processes.sh
@@ -1,0 +1,24 @@
+
+
+echo "All processes:"
+JQ_1=$(cat << EOS
+. 
+  |  {Name: .Name, Health: .Health, State: .State, ExitCode: .ExitCode, Status: .Status}
+EOS
+)
+docker compose ps --all --format json \
+  | jq --compact-output "$JQ_1"
+
+echo "Failed processes:"
+JQ_2=$(cat << EOS
+. 
+  | select( ( .Health == "healthy" ) | not )
+  | select( ( .State == "exited" and .ExitCode == 0 ) | not )
+  | select( ( .State == "running" and .Name == "agent-vite-dev-server-1" ) | not )
+  |  {Name: .Name, Health: .Health, State: .State, ExitCode: .ExitCode, Status: .Status}
+EOS
+)
+docker compose ps --all --format json \
+  | jq --compact-output "$JQ_2"
+
+echo "Manually inspect. Retry failed processes with 'docker compose up -d <service>'"

--- a/frontend/compose.yml
+++ b/frontend/compose.yml
@@ -81,7 +81,7 @@ services:
     volumes:
       # Mount the Nginx configuration file.
       - ./nginx_default.conf:/etc/nginx/conf.d/default.conf
-      - ./90-wait-for-services.sh:/docker-entrypoint.d/90-wait-for-services.sh
+      - ./docker/90-wait-for-services.sh:/docker-entrypoint.d/90-wait-for-services.sh
     ports:
       # Expose the vite server to the host machine
       - '15173:15173'

--- a/frontend/compose.yml
+++ b/frontend/compose.yml
@@ -76,33 +76,25 @@ services:
         condition: service_completed_successfully
 
   proxy:
-    image: 'nginx:1.27.3-bookworm'
+    image: 'localdomain-nginx:1.27-bookworm'
     profiles: [ frontend, all ]
     volumes:
       # Mount the Nginx configuration file.
       - ./nginx_default.conf:/etc/nginx/conf.d/default.conf
+      - ./90-wait-for-services.sh:/docker-entrypoint.d/90-wait-for-services.sh
     ports:
       # Expose the vite server to the host machine
       - '15173:15173'
     networks:
       - agent-poc
-    # Why is there no depends_on section??
-    #   The nginx conf references vite-dev-server and fastapi-dev-server.
-    #   Those two must be up and running before nginx. The reason is nginx will
-    #   try to find them on the network during its startup.
-    #   
-    #   We could automate the dependency handling. And there are many technical
-    #   choices, which would be driven by various scenarios, including system start
-    #   up. Another scenario is a restart of either vite-dev-server or fastapi-dev-server.
-    #   Ideally we don't have a cascade of restarts.
-    #
-    #   For now, we don't automate the dependency handling. It's obvious enough
-    #   when corrective action is needed: the UI has 404 not found or 502 gatway error!
-    # depends_on:
-    #   vite-dev-server:
-    #     condition: service_healthy
-    #   fastapi-dev-server:
-    #     condition: service_healthy
+    # NOTE regardng "depends_on":
+    # The nginx conf references DNS names "vite-dev-server" and "fastapi-dev-server".
+    #   These names exist in Docker's internal DNS server. Due to the mechanics of
+    #   registering names in the internal DNS server, those Docker services must be
+    #   running before this service starts.
+    # One of those names ("fastapi-dev-server") is unknown within this compose file.
+    #   Thus we avoid using the "depends_on" functionality at the compose level. Instead
+    #   we wait for those DNS names in one of the start-up scripts of the container.
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:15173']
       interval: 10s

--- a/frontend/docker/.dockerignore
+++ b/frontend/docker/.dockerignore
@@ -1,6 +1,7 @@
 
-build_image.sh
+build_images.sh
 
 Dockerfile
+*.Dockerfile
 
 *.log

--- a/frontend/docker/90-wait-for-services.sh
+++ b/frontend/docker/90-wait-for-services.sh
@@ -1,0 +1,17 @@
+
+nslookup fastapi-dev-server
+
+until [ $? -eq 0 ]
+do
+    sleep 2
+    nslookup fastapi-dev-server
+done
+
+nslookup vite-dev-server
+
+until [ $? -eq 0 ]
+do
+    sleep 2
+    nslookup vite-dev-server
+done
+

--- a/frontend/docker/build_images.sh
+++ b/frontend/docker/build_images.sh
@@ -5,3 +5,9 @@ docker buildx build \
   --no-cache \
   --tag localdomain-frontend:node-22-bookworm \
   .
+
+docker buildx build \
+  --file nginx.Dockerfile \
+  --no-cache \
+  --tag localdomain-nginx:1.27-bookworm \
+  .

--- a/frontend/docker/nginx.Dockerfile
+++ b/frontend/docker/nginx.Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.27.3-bookworm
+
+COPY ./90-wait-for-services.sh /docker-entrypoint.d/
+
+RUN apt update \
+    && apt-get install -y dnsutils

--- a/minio/docker/.dockerignore
+++ b/minio/docker/.dockerignore
@@ -1,4 +1,7 @@
 
-build_image.sh
+build_images.sh
 
 Dockerfile
+*.Dockerfile
+
+*.log

--- a/postgres/docker/.dockerignore
+++ b/postgres/docker/.dockerignore
@@ -1,6 +1,7 @@
 
-build_image.sh
+build_images.sh
 
 Dockerfile
+*.Dockerfile
 
 *.log

--- a/start_up_system.sh
+++ b/start_up_system.sh
@@ -24,29 +24,7 @@ docker compose --profile init-volumes up
 #
 docker compose --profile infrastructure up -d
 docker compose --profile backend up -d
-docker compose --profile frontend up -d
+docker compose --profile frontend --profile backend up -d
 
-sleep 5
 
-echo "All processes:"
-JQ_1=$(cat << EOS
-. 
-  |  {Name: .Name, Health: .Health, State: .State, ExitCode: .ExitCode, Status: .Status}
-EOS
-)
-docker compose ps --all --format json \
-  | jq --compact-output "$JQ_1"
-
-echo "Failed processes:"
-JQ_2=$(cat << EOS
-. 
-  | select( ( .Health == "healthy" ) | not )
-  | select( ( .State == "exited" and .ExitCode == 0 ) | not )
-  | select( ( .State == "running" and .Name == "agent-vite-dev-server-1" ) | not )
-  |  {Name: .Name, Health: .Health, State: .State, ExitCode: .ExitCode, Status: .Status}
-EOS
-)
-docker compose ps --all --format json \
-  | jq --compact-output "$JQ_2"
-
-echo "Manually inspect. Retry failed processes with 'docker compose up -d <service>'"
+./show_system_status.sh

--- a/start_up_system.sh
+++ b/start_up_system.sh
@@ -27,4 +27,4 @@ docker compose --profile backend up -d
 docker compose --profile frontend --profile backend up -d
 
 
-./show_system_status.sh
+./display_processes.sh


### PR DESCRIPTION
Our objective is a loosely-coupled system. This then means a loosely-coupled start up.

The nginx container is failing to start when DNS names for docker services (which are managed by docker's internal DNS) cannot be resolved. This runs opposite of a loosely-coupled start up.

The solution is a custom wait-for script that is tests for resolution of DNS names for docker service  via  `nslookup`. 

Another issue within the theme of loose-coupling is that the start-up script bundled both the start-up command sequences and the display of current processes. The displaying of processes is extracted into a stand-alone script.