### PR TITLE
implement workaround for NGINX's DNS cache refresh

### DIFF
--- a/frontend/nginx_default.conf
+++ b/frontend/nginx_default.conf
@@ -4,8 +4,11 @@ server {
     listen       15173;
     server_name  localhost;
 
+    set $vite_dev_server http://vite-dev-server:5173;
+    set $fastapi_dev_server http://fastapi-dev-server:8100;
+
     location / {
-        proxy_pass http://vite-dev-server:5173;
+        proxy_pass $vite_dev_server;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -13,7 +16,7 @@ server {
 
     location /api/ {
         rewrite /api/(.*) /$1  break;
-        proxy_pass http://fastapi-dev-server:8100;
+        proxy_pass $fastapi_dev_server;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
There is a long existing issue that NGINX caches DNS name resolution results. This internal caching seems to not respect the TTL (time-to-live) of the DNS result.

https://stackoverflow.com/questions/56486489/nginx-caching-dns-look-ups-and-ignoring-my-resolver-settings
https://www.f5.com/company/blog/nginx/dns-service-discovery-nginx-plus

One of the publicly available workaround is implemented here. It is to write the nginx.conf in a manner where the hostname is placed inside a variable. Because it is in a variable and not hardcoded on the "proxy_pass" line, the DNS name resolution will not be cached (See above references)
