### PR TITLE
clear selections after ingest

### DIFF
--- a/frontend/app/src/doc-mgr/DocumentTableComponent.vue
+++ b/frontend/app/src/doc-mgr/DocumentTableComponent.vue
@@ -234,6 +234,9 @@ async function ingestSelectedDocuments() {
             throw new Error('Ingest failed');
         }
 
+        // Clear the selections
+        selectedItems.value = []
+
         const data = await response.json();
         console.log('Ingest queued successfully:', data);
     } catch (error) {


### PR DESCRIPTION
After successfully launching ingestion thru the "ingest selections" button, the multi-selection column should be cleared.