### PR TITLE
clickhouse health

### DIFF
--- a/clickhouse/compose.yml
+++ b/clickhouse/compose.yml
@@ -75,7 +75,7 @@ services:
         hard: 262144
 
     healthcheck:
-      test: [ 'CMD', 'curl', '-f', 'http://localhost:8123/ping' ]
+      test: [ 'CMD', 'wget', 'http://localhost:8123/ping' ]
       interval: 10s
       timeout: 10s
       retries: 10
@@ -86,7 +86,7 @@ services:
       clickhouse:
         condition: service_healthy
 
-    image: clickhouse:24.12.3
+    image: localhost/start-gate:1.0
     profiles: [ clickhouse, infrastructure, all ]
 
     environment:

--- a/clickhouse/compose.yml
+++ b/clickhouse/compose.yml
@@ -75,7 +75,19 @@ services:
         hard: 262144
 
     healthcheck:
-      test: [ 'CMD', 'wget', 'http://localhost:8123/ping' ]
+      test:
+        # The clickhouse/clickhouse image does not have curl installed. And since the image is based on
+        # busybox, curl is not available.
+        # wget: -q    Turns off wget output, specifically the progress bar.
+        #       -S    Shows the server response, which includes the HTTP status code.
+        #       -O -  Writes the content to stdout.
+        # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+        # the IPv6 ::1 address where there is no listening port.
+        # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+        - CMD-SHELL
+        - >-
+          wget -qS -O - http://localhost:8123/ping 2>&1
+          | grep -q 'HTTP/1.1 200 OK'
       interval: 10s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
The health-check and start-gate for clickhouse need some adjustments because the clickhouse official image does not have curl.