### PR TITLE
fixed conflict between debugpy and auto-reload

### DIFF
--- a/backend/.vscode/launch.json
+++ b/backend/.vscode/launch.json
@@ -14,7 +14,21 @@
                     "localRoot": "${workspaceFolder}",
                     "remoteRoot": "."
                 }
-            ]
+            ],
+            "autoReload": {
+                "enable": true,
+                "exclude": [
+                    "**/.git/**",
+                    "**/__pycache__/**",
+                    "**/node_modules/**",
+                    "**/.metadata/**",
+                    "**/site-packages/**"
+                ],
+                "include": [
+                    "**/*.py",
+                    "**/*.pyw"
+                ]
+            }
         }
     ]
 }

--- a/backend/run_celery_flower.sh
+++ b/backend/run_celery_flower.sh
@@ -11,17 +11,12 @@ else
     exit -1
 fi
 
-PYTHON_CMD_OPTIONS="-m celery --app=core_worker flower"
-
 # Run the celery flower node.
-PYTHON_CMD="python3 ${PYTHON_CMD_OPTIONS}"
 
-# Use watchmedo to restart on file changes.
-WATCHMEDO_OPTIONS="auto-restart --directory=.  --recursive --pattern='*.py;*.env'"
-PYTHON_CMD="watchmedo ${WATCHMEDO_OPTIONS} -- ${PYTHON_CMD}"
-
-echo "${PYTHON_CMD}"
-
-# Use 'uv run' to run the celery flower node.
 PYTHONPATH=./src \
-    uv run --frozen --no-sync -- ${PYTHON_CMD}
+uv run --frozen --no-sync \
+   -- \
+   watchmedo auto-restart \
+   --directory=.  --recursive --pattern='*.py;*.env' \
+   -- \
+   celery --app=core_worker flower

--- a/backend/run_celery_worker.sh
+++ b/backend/run_celery_worker.sh
@@ -11,19 +11,12 @@ else
     exit -1
 fi
 
-PYTHON_CMD_OPTIONS="-m celery --app=core_worker worker -l INFO"
+# Run the celery worker node.
 
-PYTHON_CMD_OPTIONS="-m debugpy --listen 0.0.0.0:5678 ${PYTHON_CMD_OPTIONS}"
-
-# Run the celery worker with debugpy.
-PYTHON_CMD="python3 ${PYTHON_CMD_OPTIONS}"
-
-# Use watchmedo to restart on file changes.
-WATCHMEDO_OPTIONS="auto-restart --directory=.  --recursive --pattern='*.py;*.env'"
-PYTHON_CMD="watchmedo ${WATCHMEDO_OPTIONS} -- ${PYTHON_CMD}"
-
-echo "${PYTHON_CMD}"
-
-# Use 'uv run' to run the celery worker.
 PYTHONPATH=./src \
-    uv run --frozen --no-sync -- ${PYTHON_CMD}
+uv run --frozen --no-sync \
+   -- \
+   watchmedo auto-restart \
+   --directory=.  --recursive --pattern='*.py;*.env' \
+   -- \
+   celery --app=core_worker worker -l INFO

--- a/backend/run_fastapi_dev_server.sh
+++ b/backend/run_fastapi_dev_server.sh
@@ -11,20 +11,12 @@ else
     exit -1
 fi
 
-PYTHON_CMD_OPTIONS="-m uvicorn core_app:app --host 0.0.0.0 --port 8100"
+# Run the FastAPI server.
 
-PYTHON_CMD_OPTIONS="-m debugpy --listen 0.0.0.0:5678 ${PYTHON_CMD_OPTIONS}"
-
-# Run the FastAPI server with debugpy.
-
-PYTHON_CMD="python3 ${PYTHON_CMD_OPTIONS}"
-
-# Use watchmedo to restart on file changes.
-WATCHMEDO_OPTIONS="auto-restart --directory=.  --recursive --pattern='*.py;*.env'"
-PYTHON_CMD="watchmedo ${WATCHMEDO_OPTIONS} -- ${PYTHON_CMD}"
-
-echo "${PYTHON_CMD}"
-
-# Use 'uv run' to run the fastapi server.
 PYTHONPATH=./src \
-    uv run --frozen --no-sync -- ${PYTHON_CMD}
+uv run --frozen --no-sync \
+   -- \
+   watchmedo auto-restart \
+   --directory=.  --recursive --pattern='*.py;*.env' \
+   -- \
+   uvicorn core_app:app --host 0.0.0.0 --port 8100

--- a/backend/src/early_init/__init__.py
+++ b/backend/src/early_init/__init__.py
@@ -10,3 +10,8 @@ from .config_logging import configure_logging
 configure_env(base_env='backend.env', overrides_env='backend.overrides.env',
               secrets_env='backend.secrets.env')
 configure_logging()
+
+
+import debugpy
+
+debugpy.listen(('0.0.0.0', 5678))

--- a/backend/src/early_init/config_env.py
+++ b/backend/src/early_init/config_env.py
@@ -1,6 +1,4 @@
-import os
 from dotenv import load_dotenv
-
 
 def configure_env(base_env, secrets_env, overrides_env):
     # NOTES:

--- a/backend/src/early_init/config_logging.py
+++ b/backend/src/early_init/config_logging.py
@@ -16,21 +16,21 @@ def configure_logging():
     )
     rich_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(message)s'))
 
-    logger = logging.getLogger('demo-app')
+    logger = logging.getLogger('core')
     has_rich_handler = any([isinstance(handler, RichHandler) for handler in logger.handlers])
     if not has_rich_handler:
         logger.addHandler(rich_handler)
         logger.propagate = False
     logger.setLevel(logging.INFO)
 
-    logger2 = logging.getLogger('app')
+    logger2 = logging.getLogger('core_app')
     has_rich_handler = any([isinstance(handler, RichHandler) for handler in logger2.handlers])
     if not has_rich_handler:
         logger2.addHandler(rich_handler)
         logger2.propagate = False
     logger2.setLevel(logging.INFO)
 
-    logger2 = logging.getLogger('worker')
+    logger2 = logging.getLogger('core_worker')
     has_rich_handler = any([isinstance(handler, RichHandler) for handler in logger2.handlers])
     if not has_rich_handler:
         logger2.addHandler(rich_handler)


### PR DESCRIPTION
The debugpy module and the watchmedo auto-reload were in conflict. Using only the module imports on the command-line, either the debug or the auto-reload would correctly work but not both.

The resolution is to use code to import and launch of the debugpy module. This removes the conflicts between the two packages by firmly planting the command-and-control of debugpy inside the OS processed for the fastapi server and the celery worker.