### PR TITLE
bulk ingest all docs with uploaded status

### DIFF
--- a/backend/src/core/doc_mgr/doc/query.py
+++ b/backend/src/core/doc_mgr/doc/query.py
@@ -7,6 +7,8 @@ from sqlalchemy import and_, func
 from sqlalchemy import select, func, column
 from sqlalchemy.orm import aliased, subqueryload
 
+from core.public_models.doc import DocumentStatus
+
 from ...providers.sql_database import get_sessionmaker, DataDomain
 from ...public_models import Document, DocumentList, SortDirection
 
@@ -40,12 +42,18 @@ def get_documents(doc_uuid_list: list[str | uuid.UUID]) -> Sequence[TrackedDocum
 
 
 def list_documents(*,
-                   doc_set_id: Optional[uuid.UUID] = None, file_name: Optional[str] = None,
-                   start: Optional[int] = None, length: Optional[int] = None, sort_by: Optional[list] = None):
+                   doc_set_id: Optional[uuid.UUID | list[uuid.UUID]] = None,
+                   status: Optional[DocumentStatus | list[DocumentStatus]] = None,
+                   file_name: Optional[str] = None,
+                   start: Optional[int] = None,
+                   length: Optional[int] = None,
+                   sort_by: Optional[list] = None):
     """Return the list of files in cloud storage.
     """
 
-    existing_objs = _list_tracking_records(doc_set_id=doc_set_id, file_name=file_name,
+    existing_objs = _list_tracking_records(doc_set_id=doc_set_id,
+                                           status=status,
+                                           file_name=file_name,
                                            start=start, length=length, sort_by=sort_by)
     table_stats = get_document_statistics()
 
@@ -74,7 +82,9 @@ def list_documents(*,
 
 
 def _list_tracking_records(*,
-                           doc_set_id: Optional[uuid.UUID] = None, file_name: Optional[str] = None,
+                           doc_set_id: Optional[uuid.UUID | list[uuid.UUID]] = None,
+                           status: Optional[DocumentStatus | list[DocumentStatus]] = None,
+                           file_name: Optional[str] = None,
                            start: Optional[int] = None, length: Optional[int] = None, sort_by: Optional[list] = None):
     """Return a page of tracking records.
     
@@ -124,7 +134,17 @@ def _list_tracking_records(*,
         # Apply query filters
         where = []
         if doc_set_id is not None:
-            where.append(TrackedDocument.document_set_id == doc_set_id)
+            if isinstance(doc_set_id, list):
+                where.append(TrackedDocument.document_set_id.in_(doc_set_id))
+            elif isinstance(doc_set_id, uuid.UUID):
+                where.append(TrackedDocument.document_set_id == doc_set_id)
+        if status is not None:
+            if isinstance(status, list):
+                if len(status) > 0:
+                    where.append(TrackedDocument.status.in_(status))
+            elif isinstance(status, DocumentStatus):
+                where.append(TrackedDocument.status == status)
+
         if file_name is not None:
             where.append(TrackedDocument.filename.ilike(file_name))
         

--- a/backend/src/core/public_models/base.py
+++ b/backend/src/core/public_models/base.py
@@ -1,4 +1,3 @@
-
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 

--- a/backend/src/core/public_models/ingest.py
+++ b/backend/src/core/public_models/ingest.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-
+from typing import Optional
 
 from .base import CamelModel
 
@@ -7,4 +7,6 @@ from .base import CamelModel
 # Operator Models
 #
 class IngestRequestBody(CamelModel):
-    doc_uuids: list[UUID]
+    doc_uuids: Optional[list[UUID]] = None
+    doc_set_uuid: Optional[UUID | list[UUID]] = None
+    all_uploaded: Optional[bool] = None

--- a/backend/src/core_app/routers/documents.py
+++ b/backend/src/core_app/routers/documents.py
@@ -147,7 +147,16 @@ async def handle_ingest(
     """
     user_id = current_user.userid if current_user is not None else None
 
-    doc_uuids = body.doc_uuids if body.doc_uuids else []
+    doc_uuids = set()
+
+    if body.doc_uuids:
+        doc_uuids = set(body.doc_uuids)
+
+    if body.all_uploaded:
+        result = list_documents(doc_set_id=body.doc_set_uuid, status=DocumentStatus.UPLOADED)
+        uningested_doc_ids = [ doc.id for doc in result.documents ]
+        doc_uuids = doc_uuids.union(uningested_doc_ids)
+        logger.info('queued %d items with uploaded status', len(uningested_doc_ids))
 
     task_ids = []
     for doc_uuid in doc_uuids:

--- a/frontend/app/src/doc-mgr/DocumentTableComponent.vue
+++ b/frontend/app/src/doc-mgr/DocumentTableComponent.vue
@@ -27,12 +27,17 @@
     </v-data-table-server>
     <v-btn class="ma-2" size="large" @click="ingestSelectedItems" :disabled="selectedItemCount === 0">Ingest
         Selected</v-btn>
-        <v-btn class="ma-2" size="large" @click="deleteSelectedItems" :disabled="selectedItemCount === 0">Delete
-            Selected</v-btn>        
+    <v-btn class="ma-2" size="large" @click="ingestAllUploaded" :disabled="totalItems === 0">Ingest
+        All Uploaded</v-btn>
+    <v-btn class="ma-2" size="large" @click="deleteSelectedItems" :disabled="selectedItemCount === 0">Delete
+        Selected</v-btn>        
     <v-btn class="ma-2" size="large" @click="loadItems">Refresh</v-btn>
 
     <confirmation-dialog v-model:active="activeConfirmIngestItem" @done="closeIngestItem" @confirmed="applyIngestItem">
         Are you sure you want to ingest this item?
+    </confirmation-dialog>
+    <confirmation-dialog v-model:active="activeConfirmIngestAllUploaded" @done="closeIngestAllUploaded" @confirmed="applyIngestAllUploaded">
+        Are you sure you want to ingest all uploaded items?
     </confirmation-dialog>
     <confirmation-dialog v-model:active="activeConfirmDeleteItem" @done="closeDeleteItem" @confirmed="applyDeleteItem">
         Are you sure you want to delete this item?
@@ -316,6 +321,58 @@ async function ingestSelectedDocuments() {
 async function closeIngestSelected() {
     await loadItems()
 }
+
+
+//
+// Confirmation dialog for ingestion of all uploaded files
+//
+
+const activeConfirmIngestAllUploaded = ref(false)
+
+async function ingestAllUploaded() {
+    activeConfirmIngestAllUploaded.value = true
+}
+
+async function applyIngestAllUploaded() {
+    await ingestAllUploadedDocuments()
+}
+
+async function ingestAllUploadedDocuments() {
+    try {
+
+        const headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+        if (signedIn.value) {
+            headers['Authorization'] = `Bearer ${accessToken.value}`
+        }
+
+        const body = {
+            allUploaded: true
+        }
+
+        const response = await fetch(`/api/documents/ingest`, {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify(body, null, 2)
+        });
+
+        if (!response.ok) {
+            throw new Error('Ingest failed');
+        }
+
+        const data = await response.json();
+        console.log('Ingest queued successfully:', data);
+    } catch (error) {
+        console.error('Error ingesting:', error);
+    }
+}
+
+async function closeIngestAllUploaded() {
+    await loadItems()
+}
+
 
 
 //


### PR DESCRIPTION
Adds a button to ingest all documents with the "uploaded" status. This eases the UI burden on the main non-exceptional workflow.