### PR TITLE
debounce the autostart

### DIFF
--- a/backend/run_celery_flower.sh
+++ b/backend/run_celery_flower.sh
@@ -46,6 +46,7 @@ PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debounce-interval=5.0 \
    --directory=.  --recursive --pattern='*.py;*.env' \
    -- \
    celery --app=core_worker flower

--- a/backend/run_celery_flower.sh
+++ b/backend/run_celery_flower.sh
@@ -42,11 +42,30 @@ export POSTGRES_CHECKPOINTS_CONNECTION_URL="postgresql+psycopg://${CHECKPOINTS_P
 export FLOWER_BASIC_AUTH=$CELERY_FLOWER_USER_NAME:$CELERY_FLOWER_USER_PASSWORD
 set -o history # turn it back on
 
+# NOTE 1 regarding watchmdo:
+#   There are two approaches to launching run-and-done executables from watchmedo:
+#     * shell-command
+#     * auto-restart with --no-restart-on-command-exit
+#   The major difference between the two is: shell-command does not try to kill the prior
+#   launchs, auto-restart does try to kill. For longer-running pytest commands, the prior
+#   launch should be killed since it is only consuming resources for an obsolete set of changes.
+#   Hence the auto-restart approach is choosen.
+#
+# NOTE 2 regarding watchmedo
+#   A deep dive regarding pattern option in watchmedo:
+#     You will need to start at
+#     AutoRestartTrick (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/tricks/__init__.py#L147)
+#     arriving at PatternMatchingEventHandler (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/events.py#L292)
+#     then arriving at _match_path (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/utils/patterns.py#L24)
+if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
+    WATCH_DEBOUNCE_SECS=5.0
+fi
+
 PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
-   --debounce-interval=5.0 \
+   --debounce-interval=${WATCH_DEBOUNCE_SECS} \
    --directory=.  --recursive --pattern='*.py;*.env' \
    -- \
    celery --app=core_worker flower

--- a/backend/run_celery_worker.sh
+++ b/backend/run_celery_worker.sh
@@ -1,4 +1,3 @@
-
 set -e  # Exit immediately on error.
 set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.
@@ -40,11 +39,30 @@ export POSTGRES_VECTORS_CONNECTION_URL="postgresql+psycopg://${VECTORS_POSTGRES_
 export POSTGRES_CHECKPOINTS_CONNECTION_URL="postgresql+psycopg://${CHECKPOINTS_POSTGRES_USER_NAME}:${CHECKPOINTS_POSTGRES_USER_PASSWORD}@pgvector:5432/${ANSWERS_POSTGRES_DATABASE}"
 set -o history # turn it back on
 
+# NOTE 1 regarding watchmdo:
+#   There are two approaches to launching run-and-done executables from watchmedo:
+#     * shell-command
+#     * auto-restart with --no-restart-on-command-exit
+#   The major difference between the two is: shell-command does not try to kill the prior
+#   launchs, auto-restart does try to kill. For longer-running pytest commands, the prior
+#   launch should be killed since it is only consuming resources for an obsolete set of changes.
+#   Hence the auto-restart approach is choosen.
+#
+# NOTE 2 regarding watchmedo
+#   A deep dive regarding pattern option in watchmedo:
+#     You will need to start at
+#     AutoRestartTrick (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/tricks/__init__.py#L147)
+#     arriving at PatternMatchingEventHandler (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/events.py#L292)
+#     then arriving at _match_path (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/utils/patterns.py#L24)
+if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
+    WATCH_DEBOUNCE_SECS=5.0
+fi
+
 PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
-   --debounce-interval=5.0 \
+   --debounce-interval=${WATCH_DEBOUNCE_SECS} \
    --directory=./src  --recursive --pattern='*.py' \
    -- \
    celery --app=core_worker worker -l INFO

--- a/backend/run_celery_worker.sh
+++ b/backend/run_celery_worker.sh
@@ -44,6 +44,7 @@ PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debounce-interval=5.0 \
    --directory=./src  --recursive --pattern='*.py' \
    -- \
    celery --app=core_worker worker -l INFO

--- a/backend/run_fastapi_dev_server.sh
+++ b/backend/run_fastapi_dev_server.sh
@@ -49,6 +49,7 @@ PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debounce-interval=5.0 \
    --directory=./src  --recursive --pattern='*.py' \
    -- \
    uvicorn core_app:app --host 0.0.0.0 --port 8100

--- a/backend/run_fastapi_dev_server.sh
+++ b/backend/run_fastapi_dev_server.sh
@@ -40,16 +40,30 @@ export POSTGRES_VECTORS_CONNECTION_URL="postgresql+psycopg://${VECTORS_POSTGRES_
 export POSTGRES_CHECKPOINTS_CONNECTION_URL="postgresql+psycopg://${CHECKPOINTS_POSTGRES_USER_NAME}:${CHECKPOINTS_POSTGRES_USER_PASSWORD}@pgvector:5432/${ANSWERS_POSTGRES_DATABASE}"
 set -o history # turn it back on
 
-# A deep dive regarding pattern option in watchmedo:
-#   You will need to start at
-#   AutoRestartTrick (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/tricks/__init__.py#L147)
-#   arriving at PatternMatchingEventHandler (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/events.py#L292)
-#   then arriving at _match_path (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/utils/patterns.py#L24)
+# NOTE 1 regarding watchmdo:
+#   There are two approaches to launching run-and-done executables from watchmedo:
+#     * shell-command
+#     * auto-restart with --no-restart-on-command-exit
+#   The major difference between the two is: shell-command does not try to kill the prior
+#   launchs, auto-restart does try to kill. For longer-running pytest commands, the prior
+#   launch should be killed since it is only consuming resources for an obsolete set of changes.
+#   Hence the auto-restart approach is choosen.
+#
+# NOTE 2 regarding watchmedo
+#   A deep dive regarding pattern option in watchmedo:
+#     You will need to start at
+#     AutoRestartTrick (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/tricks/__init__.py#L147)
+#     arriving at PatternMatchingEventHandler (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/events.py#L292)
+#     then arriving at _match_path (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/utils/patterns.py#L24)
+if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
+    WATCH_DEBOUNCE_SECS=5.0
+fi
+
 PYTHONPATH=./src \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
-   --debounce-interval=5.0 \
+   --debounce-interval=${WATCH_DEBOUNCE_SECS} \
    --directory=./src  --recursive --pattern='*.py' \
    -- \
    uvicorn core_app:app --host 0.0.0.0 --port 8100

--- a/backend/run_integration_test.sh
+++ b/backend/run_integration_test.sh
@@ -45,21 +45,31 @@ set -o history # turn it back on
 # fs.inotify.max_user_watches = 524288
 #
 
-# There are two approaches to launching run-and-done executables
-# from watchmedo:
-#  * shell-command
-#  * auto-restart with --no-restart-on-command-exit
-# The first approach is better suited for quick commands. shell-command does
-# not attempt to kill the prior launchs. For longer-running pytest commands,
-# the prior launch should be killed since it is only consuming resources
-# for an obsolete trigger. Hence the second approach is choosen.
+# NOTE 1 regarding watchmdo:
+#   There are two approaches to launching run-and-done executables from watchmedo:
+#     * shell-command
+#     * auto-restart with --no-restart-on-command-exit
+#   The major difference between the two is: shell-command does not try to kill the prior
+#   launchs, auto-restart does try to kill. For longer-running pytest commands, the prior
+#   launch should be killed since it is only consuming resources for an obsolete set of changes.
+#   Hence the auto-restart approach is choosen.
 #
+# NOTE 2 regarding watchmedo
+#   A deep dive regarding pattern option in watchmedo:
+#     You will need to start at
+#     AutoRestartTrick (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/tricks/__init__.py#L147)
+#     arriving at PatternMatchingEventHandler (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/events.py#L292)
+#     then arriving at _match_path (https://github.com/gorakhargosh/watchdog/blob/561aa0425c44b9d4376163f2b909bf1b655cf71a/src/watchdog/utils/patterns.py#L24)
+if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
+    WATCH_DEBOUNCE_SECS=5.0
+fi
+
 PYTHONPATH=./src:./tests \
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
    --no-restart-on-command-exit \
-   --debounce-interval=5.0 \
+   --debounce-interval=${WATCH_DEBOUNCE_SECS} \
    --directory=./src --directory=./tests  --recursive --pattern='*.py' \
    -- \
    pytest -v -v --capture=tee-sys tests

--- a/backend/run_integration_test.sh
+++ b/backend/run_integration_test.sh
@@ -59,6 +59,7 @@ uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
    --no-restart-on-command-exit \
+   --debounce-interval=5.0 \
    --directory=./src --directory=./tests  --recursive --pattern='*.py' \
    -- \
    pytest -v -v --capture=tee-sys tests


### PR DESCRIPTION
This PR adds debouncing to the watchmedo watchers. The debouncing is a 5-second quiet interval before auto-restarting the FastAPI server, the celery worker, and the celery flower node and before relaunching the pytest test quite.