### PR TITLE
another round of fixing lint warnings

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,13 +5,14 @@ name = "python"
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  max_line_length = 120
 
 [[analyzers]]
 name = "javascript"
 
   [analyzers.meta]
   plugins = ["vue"]
-  environment = ["nodejs"]
+  environment = ["browser", "vitest"]
 
 [[analyzers]]
 name = "shell"

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .agent import get_mermaid_graph, seek_answer
 from .db_models import event_handlers
 from .doc_mgr import (
@@ -16,3 +15,24 @@ from .doc_mgr import (
 )
 from .ingest import ingest_documents, reset_worker_data
 from .status import status_check
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'get_mermaid_graph',
+    'seek_answer',
+    'event_handlers',
+    'delete_document',
+    'get_document_set_statistics',
+    'get_document_statistics',
+    'list_document_sets',
+    'list_documents',
+    'merge_chunked_document',
+    'update_document',
+    'update_document_set',
+    'update_document_status',
+    'upload_chunk',
+    'upload_document',
+    'ingest_documents',
+    'reset_worker_data',
+    'status_check',
+]

--- a/backend/src/core/agent/__init__.py
+++ b/backend/src/core/agent/__init__.py
@@ -2,3 +2,7 @@ from .agent import get_mermaid_graph, seek_answer
 
 # Import the start-up event hander so that it does not miss this event.
 from .checkpointer import checkpointer_startup
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ["get_mermaid_graph", "seek_answer"]
+

--- a/backend/src/core/agent/answer_generator.py
+++ b/backend/src/core/agent/answer_generator.py
@@ -6,7 +6,6 @@ See https://langchain-ai.github.io/langgraph/tutorials/rag/langgraph_self_rag/#g
 
 import logging
 
-
 from ..providers.chat_llm import get_chat_llm
 from .answer_citation_parser import AnswerCitationParser
 from .internal_models import AgentPrompt

--- a/backend/src/core/agent/deciders.py
+++ b/backend/src/core/agent/deciders.py
@@ -4,7 +4,6 @@ See https://langchain-ai.github.io/langgraph/tutorials/rag/langgraph_self_rag/#g
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/backend/src/core/db_models/__init__.py
+++ b/backend/src/core/db_models/__init__.py
@@ -1,7 +1,8 @@
 # Importing event_handlers will register its start-up event handler.
 from . import event_handlers
-
-# ruff: noqa: F401 # Exposes package-level imports.
 from .base import DECLARED_METADATA
 from .doc_mgr import DbTrackedDocument, DbTrackedDocumentSet
 from .prompt_mgr import DbAgentPrompt
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['event_handlers', 'DECLARED_METADATA', 'DbTrackedDocument', 'DbTrackedDocumentSet', 'DbAgentPrompt']

--- a/backend/src/core/db_models/model_ops.py
+++ b/backend/src/core/db_models/model_ops.py
@@ -183,5 +183,5 @@ def drop_all_tables():
     # Reset the Alembic migration table. If this table remains populated, our migration detection
     # logic will prevent the recreation of the registered tables.
     with engine.connect() as conn:
-        conn.execute(text(f'TRUNCATE TABLE "alembic_version" RESTART IDENTITY CASCADE'))
+        conn.execute(text('TRUNCATE TABLE "alembic_version" RESTART IDENTITY CASCADE'))
         conn.commit()

--- a/backend/src/core/doc_mgr/__init__.py
+++ b/backend/src/core/doc_mgr/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .doc import (
     add_document,
     delete_document,
@@ -18,3 +17,24 @@ from .doc_set import (
     update_document_set,
 )
 from .upload import merge_chunked_document, upload_chunk, upload_document
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'add_document',
+    'delete_document',
+    'get_document_statistics',
+    'get_documents',
+    'list_documents',
+    'update_document',
+    'update_document_status',
+    'update_tracking_record',
+    'add_document_set',
+    'delete_document_set',
+    'get_document_set_statistics',
+    'get_document_sets',
+    'list_document_sets',
+    'update_document_set',
+    'merge_chunked_document',
+    'upload_chunk',
+    'upload_document',
+]

--- a/backend/src/core/doc_mgr/doc/__init__.py
+++ b/backend/src/core/doc_mgr/doc/__init__.py
@@ -1,6 +1,17 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .add import add_document
 from .delete import delete_document
 from .query import get_documents, list_documents
 from .stats import get_document_statistics
 from .update import update_document, update_document_status, update_tracking_record
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'add_document',
+    'delete_document',
+    'get_documents',
+    'list_documents',
+    'get_document_statistics',
+    'update_document',
+    'update_document_status',
+    'update_tracking_record',
+]

--- a/backend/src/core/doc_mgr/doc_set/__init__.py
+++ b/backend/src/core/doc_mgr/doc_set/__init__.py
@@ -1,6 +1,15 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .add import add_document_set
 from .delete import delete_document_set
 from .query import get_document_sets, list_document_sets
 from .stats import get_document_set_statistics
 from .update import update_document_set
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'add_document_set',
+    'delete_document_set',
+    'get_document_sets',
+    'list_document_sets',
+    'get_document_set_statistics',
+    'update_document_set',
+]

--- a/backend/src/core/doc_mgr/doc_set/update.py
+++ b/backend/src/core/doc_mgr/doc_set/update.py
@@ -41,10 +41,10 @@ def update_doc_set_record(doc_set_uuid):
                 existing_obj = result.scalar_one()
 
         except NoResultFound as ex:
-            logger.warning('No tracking doc record found for %s', doc_uuid, exc_info=ex)
+            logger.warning('No tracking doc record found for %s', doc_set_uuid, exc_info=ex)
             return
         except MultipleResultsFound as ex:
-            logger.warning('Multiple tracking doc records found for %s', doc_uuid, exc_info=ex)
+            logger.warning('Multiple tracking doc records found for %s', doc_set_uuid, exc_info=ex)
             return
 
         with session.begin():

--- a/backend/src/core/doc_mgr/upload/__init__.py
+++ b/backend/src/core/doc_mgr/upload/__init__.py
@@ -1,2 +1,3 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .upload import merge_chunked_document, upload_chunk, upload_document
+
+__all__ = ['merge_chunked_document', 'upload_chunk', 'upload_document']

--- a/backend/src/core/ingest/__init__.py
+++ b/backend/src/core/ingest/__init__.py
@@ -1,2 +1,4 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .ingest import ingest_documents, reset_worker_data
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['ingest_documents', 'reset_worker_data']

--- a/backend/src/core/ingest/ingest.py
+++ b/backend/src/core/ingest/ingest.py
@@ -179,7 +179,7 @@ def ingest_documents(doc_ids):
     for record in tracking_records:
         _ingest_one_document(record)
 
-    logger.info(f'completed ingesting')
+    logger.info('completed ingesting')
 
     return {'status': 'completed'}
 

--- a/backend/src/core/prompt_mgr/__init__.py
+++ b/backend/src/core/prompt_mgr/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 import textwrap
 
 from core.agent.internal_models import AgentPrompt
@@ -6,7 +5,17 @@ from core.public_models import AgentPromptStatus
 
 from . import initial_prompts
 from .prompt import add_prompt, delete_prompt, get_prompt, get_prompt_statistics, list_prompts, update_prompt
-from .util import add_chat_prompt
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'add_prompt',
+    'delete_prompt',
+    'get_prompt',
+    'get_prompt_statistics',
+    'list_prompts',
+    'update_prompt',
+    'add_chat_prompt',
+]
 
 
 def add_chat_prompt(*, prompt_name: AgentPrompt, system_message: str = None, human_message: str = None):

--- a/backend/src/core/prompt_mgr/__init__.py
+++ b/backend/src/core/prompt_mgr/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     'list_prompts',
     'update_prompt',
     'add_chat_prompt',
+    'initial_prompts',
 ]
 
 

--- a/backend/src/core/prompt_mgr/prompt/__init__.py
+++ b/backend/src/core/prompt_mgr/prompt/__init__.py
@@ -1,6 +1,8 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .add import add_prompt
 from .delete import delete_prompt
 from .query import get_prompt, list_prompts
 from .stats import get_prompt_statistics
 from .update import update_prompt
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['add_prompt', 'delete_prompt', 'get_prompt', 'list_prompts', 'get_prompt_statistics', 'update_prompt']

--- a/backend/src/core/prompt_mgr/prompt/update.py
+++ b/backend/src/core/prompt_mgr/prompt/update.py
@@ -48,10 +48,10 @@ def update_prompt_record(prompt_uuid):
                 existing_obj = result.scalar_one()
 
         except NoResultFound as ex:
-            logger.warning('No tracking doc record found for %s', doc_uuid, exc_info=ex)
+            logger.warning('No tracking doc record found for %s', prompt_uuid, exc_info=ex)
             return
         except MultipleResultsFound as ex:
-            logger.warning('Multiple tracking doc records found for %s', doc_uuid, exc_info=ex)
+            logger.warning('Multiple tracking doc records found for %s', prompt_uuid, exc_info=ex)
             return
 
         with session.begin():

--- a/backend/src/core/providers/sql_database/__init__.py
+++ b/backend/src/core/providers/sql_database/__init__.py
@@ -8,4 +8,4 @@ __all__ = ['get_connection_str', 'get_engine', 'get_sessionmaker', 'get_connecti
 
 # For now, there is only one database provider
 from .base import DataDomain
-from .postgres import DataDomain, get_connection_pool, get_connection_str, get_engine, get_sessionmaker
+from .postgres import get_connection_pool, get_connection_str, get_engine, get_sessionmaker

--- a/backend/src/core/providers/vector_store/pgvector.py
+++ b/backend/src/core/providers/vector_store/pgvector.py
@@ -6,7 +6,6 @@ import logging
 from functools import cache
 
 from langchain_postgres import PGVector
-from langchain_postgres.vectorstores import PGVector
 
 from ...signals import reset_data_handler, start_up_handler
 from ..embeddings import get_embeddings

--- a/backend/src/core/public_models/__init__.py
+++ b/backend/src/core/public_models/__init__.py
@@ -1,26 +1,31 @@
-# Importing event_handlers will register its start-up event handler.
 import enum
 
-# ruff: noqa: F401 # Exposes package-level imports.
-from .agent import Answer, AnswerRequestBody, Citation
-from .doc import BulkDeleteRequestBody, Document, DocumentList, DocumentStats, DocumentStatus, DocumentUpdateRequest
-from .doc_set import (
-    DocumentSet,
-    DocumentSetAddRequest,
-    DocumentSetList,
-    DocumentSetStats,
-    DocumentSetStatus,
-    DocumentSetUpdateRequest,
-)
-from .ingest import IngestRequestBody
-from .prompt import (
-    AgentPrompt,
-    AgentPromptAddRequest,
-    AgentPromptList,
-    AgentPromptStats,
-    AgentPromptStatus,
-    AgentPromptUpdateRequest,
-)
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'Answer',
+    'AnswerRequestBody',
+    'Citation',
+    'BulkDeleteRequestBody',
+    'Document',
+    'DocumentList',
+    'DocumentStats',
+    'DocumentStatus',
+    'DocumentUpdateRequest',
+    'DocumentSet',
+    'DocumentSetAddRequest',
+    'DocumentSetList',
+    'DocumentSetStats',
+    'DocumentSetStatus',
+    'DocumentSetUpdateRequest',
+    'IngestRequestBody',
+    'AgentPrompt',
+    'AgentPromptAddRequest',
+    'AgentPromptList',
+    'AgentPromptStats',
+    'AgentPromptStatus',
+    'AgentPromptUpdateRequest',
+    'SortDirection',
+]
 
 
 class SortDirection(str, enum.Enum):

--- a/backend/src/core/public_models/__init__.py
+++ b/backend/src/core/public_models/__init__.py
@@ -1,5 +1,32 @@
 import enum
 
+from .agent import Answer, AnswerRequestBody, Citation
+from .doc import (
+    BulkDeleteRequestBody,
+    Document,
+    DocumentList,
+    DocumentStats,
+    DocumentStatus,
+    DocumentUpdateRequest,
+)
+from .doc_set import (
+    DocumentSet,
+    DocumentSetAddRequest,
+    DocumentSetList,
+    DocumentSetStats,
+    DocumentSetStatus,
+    DocumentSetUpdateRequest,
+)
+from .ingest import IngestRequestBody
+from .prompt import (
+    AgentPrompt,
+    AgentPromptAddRequest,
+    AgentPromptList,
+    AgentPromptStats,
+    AgentPromptStatus,
+    AgentPromptUpdateRequest,
+)
+
 # Explicitly define the exported names: these names are the contract of this module.
 __all__ = [
     'Answer',

--- a/backend/src/core/status/__init__.py
+++ b/backend/src/core/status/__init__.py
@@ -1,2 +1,4 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .status import status_check
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['status_check']

--- a/backend/src/core_app/__init__.py
+++ b/backend/src/core_app/__init__.py
@@ -1,3 +1,6 @@
 import early_init  # noqa: I001, F401 ## loading this module configures environment and logging
 
 from .main import app
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ["app"]

--- a/backend/src/core_app/middlewares/__init__.py
+++ b/backend/src/core_app/middlewares/__init__.py
@@ -1,2 +1,4 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .error_logger import ErrorLoggingMiddleware
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['ErrorLoggingMiddleware']

--- a/backend/src/core_app/routers/__init__.py
+++ b/backend/src/core_app/routers/__init__.py
@@ -1,2 +1,4 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from . import admin, answer, document_sets, documents
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['admin', 'answer', 'document_sets', 'documents']

--- a/backend/src/core_app/routers/documents.py
+++ b/backend/src/core_app/routers/documents.py
@@ -82,7 +82,7 @@ async def handle_upload(
     user_id = current_user.userid if current_user is not None else None
     downloadTimeUtc = datetime.fromisoformat(downloadTimeUtc)
 
-    logger.debug(f'handling %s chunk: %d %d', file.filename, chunkIndex, totalChunks)
+    logger.debug('handling %s chunk: %d %d', file.filename, chunkIndex, totalChunks)
 
     if totalChunks > 1:
         upload_chunk(

--- a/backend/src/core_worker/__init__.py
+++ b/backend/src/core_worker/__init__.py
@@ -1,8 +1,17 @@
-import early_init  # noqa: I001, F401 ## loading this module configures environment and logging
+import early_init  # noqa: I001 ## loading this module configures environment and logging
 
-# ruff: noqa: F401 # Exposes package-level imports.
 from .tasks import celery_app, ingest_task, get_worker_logger_tree, reset_data_task
 
 
 from . import signal_handlers
 from . import event_handlers
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'celery_app',
+    'ingest_task',
+    'get_worker_logger_tree',
+    'reset_data_task',
+    'signal_handlers',
+    'event_handlers',
+]

--- a/backend/src/early_init/__init__.py
+++ b/backend/src/early_init/__init__.py
@@ -6,3 +6,6 @@ early environment variables configuration.
 
 from . import config_env, config_logging
 # from . import init_debugger
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ["config_env", "config_logging"]

--- a/backend/src/global_config/__init__.py
+++ b/backend/src/global_config/__init__.py
@@ -1,2 +1,4 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .main import get_global_config
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['get_global_config']

--- a/backend/src/log_config_monitor/__init__.py
+++ b/backend/src/log_config_monitor/__init__.py
@@ -1,3 +1,5 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .logger_tree import dump_logger_tree
 from .monitor import LogConfigMonitor, get_logging_conf_monitor
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = ['dump_logger_tree', 'LogConfigMonitor', 'get_logging_conf_monitor']

--- a/backend/src/simple_auth/__init__.py
+++ b/backend/src/simple_auth/__init__.py
@@ -1,5 +1,16 @@
-# ruff: noqa: F401 # Exposes package-level imports.
 from .apply_jwt import get_current_user, get_scoped_current_user
 from .models import Scope, Token, User
 from .sim_create_jwt import create_token_from_login
 from .users import authenticate_user, retrieve_user
+
+# Explicitly define the exported names: these names are the contract of this module.
+__all__ = [
+    'get_current_user',
+    'get_scoped_current_user',
+    'Scope',
+    'Token',
+    'User',
+    'create_token_from_login',
+    'authenticate_user',
+    'retrieve_user',
+]

--- a/backend/tests/answers/test_answers.py
+++ b/backend/tests/answers/test_answers.py
@@ -11,7 +11,7 @@ pp = pprint.PrettyPrinter(indent=2, width=120)
 
 @pytest.mark.asyncio
 async def test_simple_question(api_server, ingested_doc_table, sql_sessionmaker):
-    path = f'/answer/'
+    path = '/answer/'
 
     data = {'input': 'When did deep learning emerge?'}
 

--- a/backend/tests/answers/test_answers.py
+++ b/backend/tests/answers/test_answers.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 import pytest
 
-
 logger = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(indent=2, width=120)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,2 +1,10 @@
 # The conftest.py file provides fixtures for an entire directory.
 
+pytest_plugins = [
+    "tests.fixtures.api",
+    "tests.fixtures.db",
+    "tests.fixtures.doc",
+    "tests.fixtures.doc_set",
+    "tests.fixtures.prompt",
+]
+

--- a/backend/tests/doc_mgr/doc/test_ingest.py
+++ b/backend/tests/doc_mgr/doc/test_ingest.py
@@ -42,7 +42,7 @@ async def test_ingest(api_server, populated_doc_table, sql_sessionmaker):
 
     data = {'docUuids': [str(doc_id)]}
 
-    path = f'/documents/ingest'
+    path = '/documents/ingest'
     content_type, resp = await api_server.post(path=path, content_type='json', data=data)
 
     assert content_type == 'json'

--- a/backend/tests/doc_mgr/doc/test_simple.py
+++ b/backend/tests/doc_mgr/doc/test_simple.py
@@ -40,11 +40,11 @@ async def test_insert(api_server, readonly_doc_set_table, empty_doc_table, sql_s
         'documentSetId': str(doc_set_id),
         'chunkIndex': 0,
         'totalChunks': 1,
-        'sourceUrl': f'https://example.test/test-insert-file-1.pdf',
+        'sourceUrl': 'https://example.test/test-insert-file-1.pdf',
         'contentType': 'application/pdf',
         'downloadTimeUtc': datetime.now(tz=timezone.utc).isoformat(timespec='minutes'),
     }
-    files = {'file': (f'test-insert-file-1.pdf', f'not a PDF insert 1')}
+    files = {'file': ('test-insert-file-1.pdf', 'not a PDF insert 1')}
     resp = await api_server.post(path=path, content_type='multipart', data=data, files=files)
 
     count = _get_table_count(empty_doc_table, sql_sessionmaker)

--- a/backend/tests/fixtures/doc.py
+++ b/backend/tests/fixtures/doc.py
@@ -134,7 +134,7 @@ async def ingested_doc_table(doc_table, readonly_doc_set_table, api_server, sql_
 
             doc_ids = [row[0].id for row in result]
 
-        path = f'/documents/ingest'
+        path = '/documents/ingest'
 
         data = {'docUuids': [str(doc_id) for doc_id in doc_ids]}
 
@@ -145,7 +145,7 @@ async def ingested_doc_table(doc_table, readonly_doc_set_table, api_server, sql_
         task_ids = resp.get('task_ids')
 
         if not isinstance(task_ids, list) or len(task_ids) != len(doc_ids):
-            raise RuntimeError(f'Document ingestion did not correctly queue.')
+            raise RuntimeError('Document ingestion did not correctly queue.')
 
         await asyncio.sleep(5)
 

--- a/backend/tests/prompt_mgr/prompt/test_simple.py
+++ b/backend/tests/prompt_mgr/prompt/test_simple.py
@@ -1,4 +1,3 @@
-
 import pytest
 from sqlalchemy import func, select
 


### PR DESCRIPTION
Fixed issues from earlier code clean-up, in particular removing unused imports.
* Broke unit-tests because fixtures were no longer imported. Fixed with pytest-plugin mechanism.
* Instead of disabling the lint warnings in import-only files, added an explicit __all__ for the cases of exporting names at the package level.

Fixed unnecessary f-strings.