### PR TITLE
a round of fixing lint warnings

### DIFF
--- a/backend/src/core/doc_mgr/doc/delete.py
+++ b/backend/src/core/doc_mgr/doc/delete.py
@@ -64,3 +64,8 @@ def _delete_tracking_record(doc_uuid):
         with session.begin():
             stmt = delete(DbTrackedDocument).where(DbTrackedDocument.id == doc_uuid)
             result = session.execute(stmt)
+
+    if result.rowcount == 0:
+        logger.warning('No tracking record found with UUID %s', doc_uuid)
+    else:
+        logger.debug('Successfully deleted tracking record with UUID %s', doc_uuid)

--- a/backend/src/core/doc_mgr/doc_set/delete.py
+++ b/backend/src/core/doc_mgr/doc_set/delete.py
@@ -38,3 +38,8 @@ def _delete_tracking_record(doc_set_uuid):
         with session.begin():
             stmt = delete(DbTrackedDocumentSet).where(DbTrackedDocumentSet.id == doc_set_uuid)
             result = session.execute(stmt)
+
+    if result.rowcount == 0:
+        logger.warning('No document set found with UUID %s', doc_set_uuid)
+    else:
+        logger.debug('Successfully deleted document set with UUID %s', doc_set_uuid)

--- a/backend/src/core/ingest/ingest.py
+++ b/backend/src/core/ingest/ingest.py
@@ -52,7 +52,7 @@ def ingest_documents(doc_ids):
                     doc.id = element_id
 
             if not doc.id:
-                logger.info(f'skip loading {doc}')
+                logger.info('skip loading %s', doc)
                 continue
 
             # Must convert the 'source' metadata field to a string because the metadata
@@ -159,7 +159,7 @@ def ingest_documents(doc_ids):
 
                 logger.info('pruned %d stale vectors regarding %s', len(to_remove), rel_path)
 
-        except Exception as ex:
+        except Exception as _ex:
             with update_tracking_record(doc_uuid=detached_record.id) as updateable_record:
                 if updateable_record is None:
                     # The tracking record should exist when operations are normal: the same call at

--- a/backend/src/core/prompt_mgr/prompt/delete.py
+++ b/backend/src/core/prompt_mgr/prompt/delete.py
@@ -38,3 +38,8 @@ def _delete_agent_prompt(prompt_uuid):
         with session.begin():
             stmt = delete(DbAgentPrompt).where(DbAgentPrompt.id == prompt_uuid)
             result = session.execute(stmt)
+
+    if result.rowcount == 0:
+        logger.warning('No prompt found with UUID %s', prompt_uuid)
+    else:
+        logger.debug('Successfully deleted prompt with UUID %s', prompt_uuid)

--- a/backend/src/core_app/routers/answer.py
+++ b/backend/src/core_app/routers/answer.py
@@ -23,7 +23,7 @@ async def handle_question(
 
     answer = seek_answer(user_input=params.input, thread_id=params.thread_id, user_id=user_id)
 
-    logger.info(f'returning {answer}')
+    logger.info('returning %s', answer)
 
     return answer
 
@@ -38,7 +38,7 @@ async def handler_question(
 
     answer = seek_answer(user_input=body.input, thread_id=body.thread_id, user_id=user_id)
 
-    logger.info(f'returning {answer}')
+    logger.info('returning %s', answer)
 
     return answer
 

--- a/frontend/app/src/core/AdminView.vue
+++ b/frontend/app/src/core/AdminView.vue
@@ -55,7 +55,7 @@ async function resetConfirmed() {
       throw new Error('Database reset failed')
     }
 
-    const data = await response.json()
+    await response.json()
   } catch (error) {
     console.error('Error reseting database:', error)
   }

--- a/frontend/app/src/doc-mgr/DocumentSetTableComponent.vue
+++ b/frontend/app/src/doc-mgr/DocumentSetTableComponent.vue
@@ -181,7 +181,7 @@ async function addDocumentSet() {
       throw new Error('Add failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document set added', { name: targetItem.value.name })
   } catch (error) {
     logger.apiError('Document set add failed', error, { name: targetItem.value.name })
@@ -261,7 +261,7 @@ async function editDocumentSet(doc_set_uuid) {
       throw new Error('Edit failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document set edited', { docSetId: doc_set_uuid })
   } catch (error) {
     logger.apiError('Document set edit failed', error, { docSetId: doc_set_uuid })
@@ -328,7 +328,7 @@ async function deleteDocumentSet(doc_set_uuid) {
       throw new Error('Delete failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document set deleted', { docSetId: doc_set_uuid })
   } catch (error) {
     logger.apiError('Document set deletion failed', error, { docSetId: doc_set_uuid })
@@ -407,7 +407,7 @@ async function updateDocSet(doc_uuid, doc_set_uuid) {
       throw new Error('Update failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document set updated', { docId: doc_uuid, newDocSetId: doc_set_uuid })
   } catch (error) {
     logger.apiError('Document set update failed', error, { docId: doc_uuid, newDocSetId: doc_set_uuid })

--- a/frontend/app/src/doc-mgr/DocumentTableComponent.vue
+++ b/frontend/app/src/doc-mgr/DocumentTableComponent.vue
@@ -220,7 +220,7 @@ async function ingestDocument(doc_uuid) {
       throw new Error('Ingest failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document ingest queued', { docId: doc_uuid })
   } catch (error) {
     console.error('Error ingesting:', error)
@@ -336,7 +336,7 @@ async function deleteDocument(doc_uuid) {
       throw new Error('Delete failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Document deleted', { docId: doc_uuid })
   } catch (error) {
     console.error('Error deleting:', error)
@@ -409,7 +409,7 @@ async function ingestSelectedDocuments() {
     // Clear the selections
     selectedItems.value = []
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Selected documents ingest queued', { count: body.docUuids.length })
   } catch (error) {
     console.error('Error ingesting:', error)
@@ -474,7 +474,7 @@ async function ingestAllUploadedDocuments() {
       throw new Error('Ingest failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('All uploaded documents ingest queued')
   } catch (error) {
     console.error('Error ingesting:', error)
@@ -542,7 +542,7 @@ async function deleteSelectedDocuments() {
     // Clear the selections
     selectedItems.value = []
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Selected documents deleted', { count: body.docUuids.length })
   } catch (error) {
     console.error('Error deleteing:', error)

--- a/frontend/app/src/doc-mgr/IngestAllComponent.vue
+++ b/frontend/app/src/doc-mgr/IngestAllComponent.vue
@@ -38,7 +38,7 @@ async function onIngest(event) {
       throw new Error('Ingest failed')
     }
 
-    const data = await response.json()
+    await response.json()
     logger.apiSuccess('Ingest all started')
   } catch (error) {
     logger.apiError('Ingest all failed', error)

--- a/frontend/app/src/main.js
+++ b/frontend/app/src/main.js
@@ -12,7 +12,6 @@ import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
-import { aliases, mdi } from 'vuetify/iconsets/mdi'
 
 // Labs components require a manual import and installation of the component.
 import { VDateInput } from 'vuetify/labs/VDateInput'


### PR DESCRIPTION
Clean up more unused local vars and unused imported names.
Clean up logging statements to use regular string formatting (for performance, f-strings are not liked).