### PR TITLE
reduce function complexity

### DIFF
--- a/backend/src/core/doc_mgr/doc/query.py
+++ b/backend/src/core/doc_mgr/doc/query.py
@@ -97,35 +97,9 @@ def _list_tracking_records(
     ROW_NUMBER values fall into the page range are choosen. Finally, the row
     data minus the ROW_NUMBER values are returned.
     """
-    if sort_by is None:
-        sort_by = [('name', SortDirection.ASC)]
-    elif not isinstance(sort_by, (list, tuple)):
-        raise TypeError('sort_by must be a list or tuple')
-    elif len(sort_by) == 0:
-        raise ValueError('sort_by cannot be empty')
+    order_by = _build_order_by(sort_by)
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
-
-    def _to_col(x):
-        name, direction = x
-        expr = None
-        match name:
-            case 'name':
-                expr = DbTrackedDocument.filename
-            case 'size_bytes':
-                expr = DbTrackedDocument.size_bytes
-            case 'modification_time':
-                expr = DbTrackedDocument.file_modified_time
-            case 'ingestion_time':
-                expr = DbTrackedDocument.ingested_time
-            case 'status':
-                expr = DbTrackedDocument.status
-            case _:
-                raise ValueError('unknown field name', name)
-        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
-        return expr
-
-    order_by = [_to_col(x) for x in sort_by]
 
     with sessionmaker() as session:
         paginate = start is not None and length is not None
@@ -133,21 +107,7 @@ def _list_tracking_records(
         core_query = select(DbTrackedDocument)
 
         # Apply query filters
-        where = []
-        if doc_set_id is not None:
-            if isinstance(doc_set_id, list):
-                where.append(DbTrackedDocument.document_set_id.in_(doc_set_id))
-            elif isinstance(doc_set_id, uuid.UUID):
-                where.append(DbTrackedDocument.document_set_id == doc_set_id)
-        if status is not None:
-            if isinstance(status, list):
-                if len(status) > 0:
-                    where.append(DbTrackedDocument.status.in_(status))
-            elif isinstance(status, DocumentStatus):
-                where.append(DbTrackedDocument.status == status)
-
-        if file_name is not None:
-            where.append(DbTrackedDocument.filename.ilike(file_name))
+        where = _build_query_filter(doc_set_id, status, file_name)
 
         if len(where) > 1:
             core_query = core_query.where(and_(*where))
@@ -187,3 +147,88 @@ def _list_tracking_records(
         existing_objs = result.scalars().all()
 
     return existing_objs
+
+
+def _build_query_filter(
+    doc_set_id: Optional[uuid.UUID | list[uuid.UUID]],
+    status: Optional[DocumentStatus | list[DocumentStatus]],
+    file_name: Optional[str],
+):
+    """
+    Build WHERE clause conditions from filter parameters.
+
+    Args:
+        doc_set_id: Single document set UUID or list of UUIDs to filter by.
+                   If None, no document set filtering is applied.
+        status: Single DocumentStatus or list of statuses to filter by.
+               If None, no status filtering is applied.
+        file_name: Filename pattern for ILIKE matching (case-insensitive).
+                  If None, no filename filtering is applied.
+
+    Returns:
+        list: List of SQLAlchemy WHERE clause conditions that can be used
+              with and_() or applied individually to a query.
+    """
+    where = []
+    if doc_set_id is not None:
+        if isinstance(doc_set_id, list):
+            where.append(DbTrackedDocument.document_set_id.in_(doc_set_id))
+        elif isinstance(doc_set_id, uuid.UUID):
+            where.append(DbTrackedDocument.document_set_id == doc_set_id)
+    if status is not None:
+        if isinstance(status, list):
+            if len(status) > 0:
+                where.append(DbTrackedDocument.status.in_(status))
+        elif isinstance(status, DocumentStatus):
+            where.append(DbTrackedDocument.status == status)
+
+    if file_name is not None:
+        where.append(DbTrackedDocument.filename.ilike(file_name))
+    return where
+
+
+def _build_order_by(sort_by: Optional[list] = None):
+    """
+    Build ORDER BY clause expressions from sort specification.
+
+    Args:
+        sort_by: List or tuple of (field_name, direction) tuples specifying sort criteria.
+                If None, defaults to [('name', SortDirection.ASC)].
+                Supported field names: 'name', 'size_bytes', 'modification_time', 'ingestion_time', 'status'
+                Direction should be SortDirection.ASC or SortDirection.DESC
+
+    Returns:
+        list: List of SQLAlchemy order_by expressions that can be passed to query.order_by()
+
+    Raises:
+        TypeError: If sort_by is not a list or tuple
+        ValueError: If sort_by is empty or contains unknown field names
+    """
+    if sort_by is None:
+        sort_by = [('name', SortDirection.ASC)]
+    elif not isinstance(sort_by, (list, tuple)):
+        raise TypeError('sort_by must be a list or tuple')
+    elif len(sort_by) == 0:
+        raise ValueError('sort_by cannot be empty')
+
+    def _to_col(x):
+        name, direction = x
+        expr = None
+        match name:
+            case 'name':
+                expr = DbTrackedDocument.filename
+            case 'size_bytes':
+                expr = DbTrackedDocument.size_bytes
+            case 'modification_time':
+                expr = DbTrackedDocument.file_modified_time
+            case 'ingestion_time':
+                expr = DbTrackedDocument.ingested_time
+            case 'status':
+                expr = DbTrackedDocument.status
+            case _:
+                raise ValueError('unknown field name', name)
+        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
+        return expr
+
+    order_by = [_to_col(x) for x in sort_by]
+    return order_by

--- a/backend/src/core/doc_mgr/doc_set/query.py
+++ b/backend/src/core/doc_mgr/doc_set/query.py
@@ -75,31 +75,9 @@ def _list_tracking_document_sets(
     sort_by: Optional[list] = None,
 ):
     """Return tracking set when matched to specified document UUID."""
-    if sort_by is None:
-        sort_by = [('name', SortDirection.ASC)]
-    elif not isinstance(sort_by, (list, tuple)):
-        raise TypeError('sort_by must be a list or tuple')
-    elif len(sort_by) == 0:
-        raise ValueError('sort_by cannot be empty')
+    order_by = _build_order_by(sort_by)
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
-
-    def _to_col(x):
-        name, direction = x
-        expr = None
-        match name:
-            case 'name':
-                expr = DbTrackedDocumentSet.name
-            case 'is_new_doc_default':
-                expr = DbTrackedDocumentSet.is_new_doc_default
-            case 'is_public_viewable':
-                expr = DbTrackedDocumentSet.is_public_viewable
-            case _:
-                raise ValueError('unknown field name', name)
-        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
-        return expr
-
-    order_by = [_to_col(x) for x in sort_by]
 
     with sessionmaker() as session:
         paginate = start is not None and length is not None
@@ -108,13 +86,7 @@ def _list_tracking_document_sets(
         core_query = select(DbTrackedDocumentSet)
 
         # Apply query filters
-        where = []
-        if name is not None:
-            where.append(DbTrackedDocumentSet.name.ilike(name))
-        if is_default is not None:
-            where.append(DbTrackedDocumentSet.is_new_doc_default == is_default)
-        if is_public is not None:
-            where.append(DbTrackedDocumentSet.is_public_viewable == is_public)
+        where = _build_query_filter(name, is_default, is_public)
 
         if len(where) > 1:
             core_query = core_query.where(and_(*where))
@@ -151,3 +123,76 @@ def _list_tracking_document_sets(
 
     # The returned objects are detached from the closed session.
     return existing_objs
+
+
+def _build_query_filter(
+    name: Optional[str] = None, is_default: Optional[bool] = None, is_public: Optional[bool] = None
+):
+    """
+    Build WHERE clause conditions for filtering document sets.
+
+    Args:
+        name: Optional string to filter by document set name using case-insensitive LIKE matching.
+              If provided, filters for document sets whose name contains this string.
+        is_default: Optional boolean to filter by whether the document set is the default
+                   for new documents. If True, returns only default sets; if False, returns
+                   only non-default sets; if None, no filtering is applied.
+        is_public: Optional boolean to filter by whether the document set is publicly viewable.
+                  If True, returns only public sets; if False, returns only private sets;
+                  if None, no filtering is applied.
+
+    Returns:
+        list: List of SQLAlchemy WHERE clause expressions that can be applied to a query.
+              Returns an empty list if no filters are specified.
+    """
+    where = []
+    if name is not None:
+        where.append(DbTrackedDocumentSet.name.ilike(name))
+    if is_default is not None:
+        where.append(DbTrackedDocumentSet.is_new_doc_default == is_default)
+    if is_public is not None:
+        where.append(DbTrackedDocumentSet.is_public_viewable == is_public)
+    return where
+
+
+def _build_order_by(sort_by: Optional[list] = None):
+    """
+    Build ORDER BY clause expressions from sort specification.
+
+    Args:
+        sort_by: List or tuple of (field_name, direction) tuples specifying sort criteria.
+                If None, defaults to [('name', SortDirection.ASC)].
+                Supported field names: 'name', 'is_new_doc_default', 'is_public_viewable'
+                Direction should be SortDirection.ASC or SortDirection.DESC
+
+    Returns:
+        list: List of SQLAlchemy order_by expressions that can be passed to query.order_by()
+
+    Raises:
+        TypeError: If sort_by is not a list or tuple
+        ValueError: If sort_by is empty or contains unknown field names
+    """
+    if sort_by is None:
+        sort_by = [('name', SortDirection.ASC)]
+    elif not isinstance(sort_by, (list, tuple)):
+        raise TypeError('sort_by must be a list or tuple')
+    elif len(sort_by) == 0:
+        raise ValueError('sort_by cannot be empty')
+
+    def _to_col(x):
+        name, direction = x
+        expr = None
+        match name:
+            case 'name':
+                expr = DbTrackedDocumentSet.name
+            case 'is_new_doc_default':
+                expr = DbTrackedDocumentSet.is_new_doc_default
+            case 'is_public_viewable':
+                expr = DbTrackedDocumentSet.is_public_viewable
+            case _:
+                raise ValueError('unknown field name', name)
+        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
+        return expr
+
+    order_by = [_to_col(x) for x in sort_by]
+    return order_by

--- a/backend/src/core/prompt_mgr/prompt/query.py
+++ b/backend/src/core/prompt_mgr/prompt/query.py
@@ -84,29 +84,9 @@ def _list_agent_prompts(
     sort_by: Optional[list] = None,
 ):
     """Return prompts when matched to specified propmt UUID."""
-    if sort_by is None:
-        sort_by = [('name', SortDirection.ASC)]
-    elif not isinstance(sort_by, (list, tuple)):
-        raise TypeError('sort_by must be a list or tuple')
-    elif len(sort_by) == 0:
-        raise ValueError('sort_by cannot be empty')
+    order_by = _build_order_by(sort_by)
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
-
-    def _to_col(x):
-        name, direction = x
-        expr = None
-        match name:
-            case 'name':
-                expr = DbAgentPrompt.name
-            case 'status':
-                expr = DbAgentPrompt.status
-            case _:
-                raise ValueError('unknown field name', name)
-        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
-        return expr
-
-    order_by = [_to_col(x) for x in sort_by]
 
     with sessionmaker() as session:
         paginate = start is not None and length is not None
@@ -115,13 +95,7 @@ def _list_agent_prompts(
         core_query = select(DbAgentPrompt)
 
         # Apply query filters
-        where = []
-        if name is not None:
-            where.append(DbAgentPrompt.name.ilike(name))
-        if status is not None:
-            where.append(DbAgentPrompt.status == status)
-        if owner_type is not None:
-            where.append(DbAgentPrompt.owner_type == owner_type)
+        where = _build_query_filter(name, status, owner_type)
 
         if len(where) > 1:
             core_query = core_query.where(and_(*where))
@@ -158,3 +132,71 @@ def _list_agent_prompts(
 
     # The returned objects are detached from the closed session.
     return existing_objs
+
+
+def _build_query_filter(name: Optional[str], status: Optional[AgentPromptStatus], owner_type: Optional[OwnerType]):
+    """
+    Build WHERE clause conditions for filtering agent prompts.
+
+    Args:
+        name: Optional string to filter prompts by name using case-insensitive matching.
+              If provided, uses SQL ILIKE for partial matching.
+        status: Optional AgentPromptStatus to filter prompts by their current status.
+                If provided, performs exact equality match.
+        owner_type: Optional OwnerType to filter prompts by their owner type.
+                   If provided, performs exact equality match.
+
+    Returns:
+        list: List of SQLAlchemy WHERE clause conditions that can be combined
+              with AND operator for filtering DbAgentPrompt records.
+              Returns empty list if no filters are specified.
+    """
+    where = []
+    if name is not None:
+        where.append(DbAgentPrompt.name.ilike(name))
+    if status is not None:
+        where.append(DbAgentPrompt.status == status)
+    if owner_type is not None:
+        where.append(DbAgentPrompt.owner_type == owner_type)
+    return where
+
+
+def _build_order_by(sort_by: Optional[list] = None):
+    """
+    Build ORDER BY clause expressions from sort specification.
+
+    Args:
+        sort_by: List or tuple of (field_name, direction) tuples specifying sort criteria.
+                If None, defaults to [('name', SortDirection.ASC)].
+                Supported field names: 'name', 'status'
+                Direction should be SortDirection.ASC or SortDirection.DESC
+
+    Returns:
+        list: List of SQLAlchemy order_by expressions that can be passed to query.order_by()
+
+    Raises:
+        TypeError: If sort_by is not a list or tuple
+        ValueError: If sort_by is empty or contains unknown field names
+    """
+    if sort_by is None:
+        sort_by = [('name', SortDirection.ASC)]
+    elif not isinstance(sort_by, (list, tuple)):
+        raise TypeError('sort_by must be a list or tuple')
+    elif len(sort_by) == 0:
+        raise ValueError('sort_by cannot be empty')
+
+    def _to_col(x):
+        name, direction = x
+        expr = None
+        match name:
+            case 'name':
+                expr = DbAgentPrompt.name
+            case 'status':
+                expr = DbAgentPrompt.status
+            case _:
+                raise ValueError('unknown field name', name)
+        expr = expr.desc() if direction == SortDirection.DESC else expr.asc()
+        return expr
+
+    return_value = [_to_col(x) for x in sort_by]
+    return return_value


### PR DESCRIPTION
There were 3 querying functions with a high amount of complexity.

The complexities came from these reasons:

* The conditional logic for building the order_by expression.
* The conditional logic for building the where expression.
* The conditional logic for building CTE base pagination. 

The first two (order_by and where building) were extracted into their own private functions.