### PR TITLE
reconfigure eslint

### DIFF
--- a/frontend/app/eslint.config.cjs
+++ b/frontend/app/eslint.config.cjs
@@ -46,7 +46,9 @@ module.exports = [
       
       // Vue-specific rules
       'vue/multi-word-component-names': 'warn',
-      'vue/attribute-hyphenation': ['error', 'always']
+      'vue/component-api-style': ['error', ['script setup']],
+      'vue/attribute-hyphenation': ['error', 'always'],
+      'vue/no-v-model-argument': 'off' // Explicitly disable v-model argument rule
     },
     languageOptions: {
       ecmaVersion: 2022,


### PR DESCRIPTION
explicitly disable vue/v-model-arguments .. in case we have an older rule set.