### PR TITLE
correctly fix security issues

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN \
     #
     # See: https://github.com/Unstructured-IO/unstructured/blob/main/scripts/install-pandoc.sh
     #
-    && curl -L -O --proto-redir https \
+    && curl -L -O --proto "=https" \
         https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-linux-amd64.tar.gz \
     && tar xvf pandoc-3.7.0.2-linux-amd64.tar.gz \
     && cd pandoc-3.7.0.2 \

--- a/backend/docker/python_bookworm_cuda11.Dockerfile
+++ b/backend/docker/python_bookworm_cuda11.Dockerfile
@@ -26,7 +26,7 @@ RUN \
         curl \
         gnupg2 \
     && apt-get clean \
-    && curl -fsSL  --proto-redir https \
+    && curl -fsSL --proto "=https" \
         https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/3bf863cc.pub \
         | apt-key add - \
     && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64 /" > /etc/apt/sources.list.d/cuda.list \

--- a/backend/docker/python_bookworm_cuda12.Dockerfile
+++ b/backend/docker/python_bookworm_cuda12.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         curl \
         gnupg2 \
     && apt-get clean \
-    && curl -fsSL --proto-redir https \
+    && curl -fsSL --proto "=https" \
         https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub \
         | apt-key add - \
     && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64 /" > /etc/apt/sources.list.d/cuda.list \

--- a/postgres/docker/Dockerfile
+++ b/postgres/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   #
   # Install pgvector
   #
-  && curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  && curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail --proto "=https" https://www.postgresql.org/media/keys/ACCC4CF8.asc \
   && apt-get install -y postgresql-17-pgvector \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The previous PR (#100) was HTTPS-only for only redirects.
This is HTTPS-only also for initial requests.