### PR TITLE
fix lint warnings

### DIFF
--- a/backend/src/core/agent/agent.py
+++ b/backend/src/core/agent/agent.py
@@ -28,6 +28,7 @@ from .document_guards import check_retrieval_with_nemo, check_retrieval_with_pre
 from .document_retriever import query_documents
 from .hallucination_grader import grade_hallucination
 from .input_guards import check_input_with_nemo, check_input_with_presidio
+from .lib_config import get_lib_config
 from .postprocess import add_response_to_history
 from .preprocess import add_input_to_history
 from .question_rewriter import rewrite_question
@@ -465,6 +466,8 @@ def seek_answer(user_input: str, thread_id: Optional[uuid.UUID], user_id: Option
     """
     logger.info('user input: %s  thread_id: %s', user_input, thread_id)
 
+    config = get_lib_config()
+
     if not thread_id:
         thread_id = uuid.uuid4()
     elif isinstance(thread_id, str):
@@ -477,7 +480,8 @@ def seek_answer(user_input: str, thread_id: Optional[uuid.UUID], user_id: Option
     logger.info('streaming_mode: %s', graph.stream_mode)
 
     # Initialize Langfuse CallbackHandler for Langchain (tracing)
-    langfuse_handler = CallbackHandler(session_id=thread_id.hex, user_id=user_id, sample_rate=1.0)
+    if config.enable_langfuse_tracing:
+        langfuse_handler = CallbackHandler(session_id=thread_id.hex, user_id=user_id, sample_rate=1.0)
 
     # See https://langchain-ai.github.io/langgraph/cloud/how-tos/stream_updates/
 
@@ -491,7 +495,8 @@ def seek_answer(user_input: str, thread_id: Optional[uuid.UUID], user_id: Option
         if user_id:
             extra_data['user_id'] = user_id
         run_config = {'recursion_limit': 30, 'configurable': extra_data}
-        run_config['callbacks'] = [langfuse_handler]
+        if langfuse_handler is not None:
+            run_config['callbacks'] = [langfuse_handler]
         for output in graph.stream(input=graph_input, config=run_config):
             for key, value in output.items():
                 # Node
@@ -504,27 +509,25 @@ def seek_answer(user_input: str, thread_id: Optional[uuid.UUID], user_id: Option
 
     # If we haven't assigned the answer yet, then pull it from the
     # generated output.
-    answer = latest_value.get('answer', None)
+    answer = latest_value.get('answer', '')
     citations = []
-    if answer is not None:
+
+    if answer:
         citations = latest_value.get('citations', [])
-
-    # If there was no generate output (for example, because there was an error),
-    # then set it to a hard-wired generic answer.
-    if answer is None:
+        citations = [
+            Citation(
+                doc_uuid=citation['doc_id'],
+                text=citation['text'],
+                source_url=citation.get('source_url'),
+                page_number=citation.get('page_number'),
+                file_name=citation.get('file_name'),
+            )
+            for citation in citations
+        ]
+    else:
+        # If there was no generate output (for example, because there was an error),
+        # then set it to a hard-wired generic answer.
         answer = 'I cannot find the answer to this question at this moment'
-        citations = []
-
-    citations = [
-        Citation(
-            doc_uuid=citation['doc_id'],
-            text=citation['text'],
-            source_url=citation.get('source_url'),
-            page_number=citation.get('page_number'),
-            file_name=citation.get('file_name'),
-        )
-        for citation in citations
-    ]
 
     logger.info('answer: %s', answer)
     return Answer(question=user_input, answer=answer, citations=citations, thread_id=thread_id, user_id=user_id)

--- a/backend/src/core/doc_mgr/doc/delete.py
+++ b/backend/src/core/doc_mgr/doc/delete.py
@@ -52,10 +52,9 @@ def _delete_tracking_record(doc_uuid):
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
 
-    with sessionmaker() as session:
-        with session.begin():
-            stmt = delete(DbTrackedDocument).where(DbTrackedDocument.id == doc_uuid)
-            result = session.execute(stmt)
+    with sessionmaker() as session, session.begin():
+        stmt = delete(DbTrackedDocument).where(DbTrackedDocument.id == doc_uuid)
+        result = session.execute(stmt)
 
     if result.rowcount == 0:
         logger.warning('No tracking record found with UUID %s', doc_uuid)

--- a/backend/src/core/doc_mgr/doc_set/delete.py
+++ b/backend/src/core/doc_mgr/doc_set/delete.py
@@ -34,10 +34,9 @@ def _delete_tracking_record(doc_set_uuid):
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
 
-    with sessionmaker() as session:
-        with session.begin():
-            stmt = delete(DbTrackedDocumentSet).where(DbTrackedDocumentSet.id == doc_set_uuid)
-            result = session.execute(stmt)
+    with sessionmaker() as session, session.begin():
+        stmt = delete(DbTrackedDocumentSet).where(DbTrackedDocumentSet.id == doc_set_uuid)
+        result = session.execute(stmt)
 
     if result.rowcount == 0:
         logger.warning('No document set found with UUID %s', doc_set_uuid)

--- a/backend/src/core/lib_config.py
+++ b/backend/src/core/lib_config.py
@@ -120,6 +120,8 @@ class LibrarySettings(BaseSettings):
 
     vector_store_type: str = Field(default='weaviate', validation_alias='VECTOR_STORE_TYPE')
 
+    enable_langfuse_tracing: bool = Field(default=True, validation_alias='ENABLE_LANGFUSE_TRACKING')
+
     chat_llm_type: LowerCaseStr = Field(default='', validation_alias='CHAT_LLM_TYPE')
     llm_has_structured_output: bool = Field(default=False, validation_alias='LLM_HAS_STRUCTURED_OUTPUT')
 

--- a/backend/src/core/prompt_mgr/prompt/delete.py
+++ b/backend/src/core/prompt_mgr/prompt/delete.py
@@ -34,10 +34,9 @@ def _delete_agent_prompt(prompt_uuid):
 
     sessionmaker = get_sessionmaker(DataDomain.ANSWERS)
 
-    with sessionmaker() as session:
-        with session.begin():
-            stmt = delete(DbAgentPrompt).where(DbAgentPrompt.id == prompt_uuid)
-            result = session.execute(stmt)
+    with sessionmaker() as session, session.begin():
+        stmt = delete(DbAgentPrompt).where(DbAgentPrompt.id == prompt_uuid)
+        result = session.execute(stmt)
 
     if result.rowcount == 0:
         logger.warning('No prompt found with UUID %s', prompt_uuid)

--- a/backend/src/core_app/auth/api_key.py
+++ b/backend/src/core_app/auth/api_key.py
@@ -58,20 +58,20 @@ async def get_current_user_from_api_key(api_key: str) -> User | None:
     if api_key in static_api_keys:
         user = static_api_keys[api_key]
 
-        logger.debug(f"Authenticated user '{user.userid}' using static API key.")
+        logger.debug("Authenticated user '%s' using static API key.", user.userid)
 
         if user:
             return user
 
         # This case implies the API key was valid but the user does not exist.
         # This might indicate an inconsistency in the configuration.
-        logger.warning(f'API key valid for {user.userid}, but failed with incomplete configuration.')
+        logger.warning('API key valid for %s, but failed with incomplete configuration.', user.userid)
         raise_credentials_error('X-API-Key')  # Treat as overall credential failure
 
     if api_key:
         # The API key itself was invalid.
         # We raise an error because an auth attempt was made with a bad key.
-        logger.warning(f'Invalid API key provided: {api_key[:5]}...')
+        logger.warning('Invalid API key provided: %s...', api_key[:5])
         raise_credentials_error('X-API-Key')
 
     return None


### PR DESCRIPTION
Fixed some lint warnings.

In one case, the lint warning was not an automatic fix: a more thoughtful look showed that the original concept of an configuration-driven conditional usage of langfuse tracing was incorrectly implemented as an unconditional usage.