### PR TITLE
queued state

### DIFF
--- a/backend/run_lint.sh
+++ b/backend/run_lint.sh
@@ -17,12 +17,6 @@ uvx autopep8 \
   --in-place --recursive \
   src tests
 
-# Fix doc line length (W505) - wrap docstrings at 100 characters to match ruff config
-uvx docformatter \
-  --wrap-summaries 100 --wrap-descriptions 100 \
-  --in-place --recursive \
-  src tests
-
 # Sort the import statement
 uvx ruff check --select I --fix src tests
 

--- a/backend/src/core/doc_mgr/doc_set/add.py
+++ b/backend/src/core/doc_mgr/doc_set/add.py
@@ -39,7 +39,7 @@ def _add_or_update_document_set(name: str, is_new_doc_default: bool, is_public_v
             if existing_obj:
                 doc_set_uuid = existing_obj.id
                 existing_obj.name = name
-                existing_obj.s3_rel_path=s3_rel_path
+                existing_obj.s3_rel_path = s3_rel_path
                 existing_obj.is_new_doc_default = is_new_doc_default
                 existing_obj.is_public_viewable = is_public_viewable
                 existing_obj.last_user_id = user_id

--- a/backend/src/core/ingest/ingest.py
+++ b/backend/src/core/ingest/ingest.py
@@ -36,7 +36,7 @@ def _load_one_source(
     Uses the appropriate document loader for the file type and yields individual document chunks
     with enhanced metadata including document set ID, source URL, content type, and download time.
     """
-    loader = get_doc_loader(file_path=source_path)
+    loader = get_doc_loader(file_path=source_path, strategy='fast')
 
     check_in_interval = 10
     check_in_time = datetime.now() + timedelta(seconds=check_in_interval)

--- a/backend/src/core/providers/doc_loader/unstructured.py
+++ b/backend/src/core/providers/doc_loader/unstructured.py
@@ -47,7 +47,7 @@ def start(sender):
 #
 # Create a document loader.
 #
-def get_doc_loader(file_path: Path | list[Path]):
+def get_doc_loader(file_path: Path | list[Path], strategy: str = 'hi_res', chunking_strategy: str = 'by_title'):
     """
     Return an UnstructuredLoader instance for the given file path(s).
 

--- a/backend/src/core_worker/event_handlers.py
+++ b/backend/src/core_worker/event_handlers.py
@@ -1,4 +1,24 @@
+"""
+Real-time monitoring of Celery events.
+
+This module provides a mechanism to monitor Celery worker and task events
+in real-time. It uses a background thread to listen for events and can be
+used to trigger actions based on the state of the Celery cluster.
+
+The primary use case is for monitoring, not for customizing task or worker
+lifecycles, for which Celery signals are more appropriate.
+
+See Also:
+    https://docs.celeryq.dev/en/stable/userguide/monitoring.html#real-time-processing
+
+"""
+
 import logging
+import threading
+from uuid import UUID
+
+from celery import Celery
+from celery.signals import worker_init, worker_shutting_down
 
 from core import update_document_status
 from core.public_models import DocumentStatus
@@ -15,51 +35,170 @@ logger = logging.getLogger(__name__)
 #
 
 
-def setup_monitoring(app):
+class CeleryMonitoringThread:
     """
-    Set up monitoring and metrics collection for the Celery application.
+    Manages a background thread for monitoring Celery events.
 
-    Configures application-level monitoring infrastructure when the Celery worker application is
-    initialized. This is typically called during the worker startup process.
+    This class encapsulates the logic for starting and stopping a thread that
+    listens for Celery events. It is designed to be controlled by Celery worker
+    signals to ensure clean startup and shutdown.
 
-    Monitors worker online/offline events and task state changes, updating document status when
-    tasks are sent to the queue.
+    Attributes:
+        celery_app: The Celery application instance.
+        state: The Celery event state object.
+        thread: The background monitoring thread.
+        connection: The connection to the message broker for reading events.
+        receiver: The Celery event receiver.
+
     """
-    # A State builds an In-memory representation of cluster state from the event stream.
-    state = app.events.State()
 
-    def announce_worker_online(event):
-        """Log when a Celery worker comes online and update state tracking."""
-        state.event(event)
+    def __init__(self, celery_app: Celery):
+        """
+        Initializes the CeleryMonitoringThread.
 
-        logger.info('Worker is online: %s', event['name'])
+        Args:
+            celery_app: The Celery application instance.
 
-    def announce_worker_offline(event):
-        """Log when a Celery worker goes offline and update state tracking."""
-        state.event(event)
+        """
+        self.celery_app = celery_app
+        self.state = celery_app.events.State()
+        self.thread = None
+        self.connection = None
+        self.receiver = None
 
-        logger.info('Worker is offline: %s', event['name'])
+    def start(self):
+        """Starts the monitoring thread."""
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
 
-    def announce_sent_tasks(event):
-        """Log when a task is sent and update document status to QUEUED."""
-        state.event(event)
-
-        # task name is sent only with -received event, and state
-        # will keep track of this for us.
-        task = state.tasks.get(event['uuid'])
-
-        update_document_status(event['uuid'], DocumentStatus.QUEUED)
-
-        logger.info('Task sent: %s[%s] %s', task.name, task.uuid, task.info())
-
-    with app.connection() as connection:
-        recv = app.events.Receiver(
-            connection,
+    def _run(self):
+        """The main loop for the monitoring thread."""
+        self.connection = self.celery_app.connection_for_read()
+        self.receiver = self.celery_app.events.Receiver(
+            self.connection,
             handlers={
-                'worker-online': announce_worker_online,
-                'worker-offline': announce_worker_offline,
-                'task-sent': announce_sent_tasks,
-                '*': state.event,
+                'worker-online': self._on_worker_online,
+                'worker-offline': self._on_worker_offline,
+                'task-sent': self._on_task_sent,
+                '*': self.state.event,
             },
         )
-        recv.capture(limit=None, timeout=None, wakeup=True)
+        # The capture call is blocking and will run until the connection is closed.
+        self.receiver.capture(limit=None, timeout=None, wakeup=True)
+
+    def stop(self):
+        """Stops the monitoring thread gracefully."""
+        if self.connection:
+            self.connection.close()
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=5.0)
+
+    def _on_worker_online(self, event):
+        """
+        Logs when a Celery worker comes online and updates state tracking.
+
+        Args:
+            event: The worker-online event.
+
+        """
+        try:
+            self.state.event(event)
+            logger.info('Worker is online: %s', event)
+        except Exception as ex:
+            logger.warning('Error during working-online event', exc_info=ex)
+
+    def _on_worker_offline(self, event):
+        """
+        Logs when a Celery worker goes offline and updates state tracking.
+
+        Args:
+            event: The worker-offline event.
+
+        """
+        try:
+            self.state.event(event)
+            logger.info('Worker is offline: %s', event)
+        except Exception as ex:
+            logger.warning('Error during working-off event', exc_info=ex)
+
+    def _safe_eval_kwargs(self, kwargs_str: str):
+        """
+        Safely evaluates a string representation of kwargs, allowing for UUID objects.
+
+        Args:
+            kwargs_str: The string representation of the keyword arguments.
+
+        Returns:
+            The evaluated keyword arguments as a dictionary.
+
+        """
+        # eval() can be dangerous if used with untrusted input. However, in this case,
+        # we are controlling the environment by providing a restricted globals dictionary.
+        # We only make the UUID constructor available, which is needed to parse the
+        # kwargs string from Celery events.
+        safe_globals = {'UUID': UUID}
+        return eval(kwargs_str, {'__builtins__': {}}, safe_globals)
+
+    def _on_task_sent(self, event):
+        """
+        Logs when a task is sent and updates document status to QUEUED.
+
+        Args:
+            event: The task-sent event.
+
+        """
+        try:
+            self.state.event(event)
+
+            logger.info('Task sent: %s', self.state)
+            logger.info('Task sent: %s', self.state.tasks)
+
+            task = self.state.tasks.get(event['uuid'])
+
+            logger.info('Task sent: %s', event)
+            logger.info('Task sent: %s', task)
+            logger.info('Task sent: %s', task.kwargs)
+
+            if task.name == 'ingest-docs':
+                # The `ingest-docs` task is called with a `doc_ids` keyword argument.
+                #
+                # When a task is sent, Celery serializes the keyword arguments into a string
+                # representation. We use a custom safe evaluation function to deserialize
+                # the string back into a dictionary.
+                # See: https://github.com/celery/celery/blob/main/celery/app/amqp.py#L322
+                kwargs = self._safe_eval_kwargs(task.kwargs)
+                doc_ids = kwargs.get('doc_ids')
+                if doc_ids:
+                    for doc_id in doc_ids:
+                        update_document_status(doc_id, DocumentStatus.QUEUED)
+
+            logger.info('Task sent: %s[%s] %s', task.name, task.uuid, task.info())
+        except Exception as ex:
+            logger.warning('Error during task-sent event', exc_info=ex)
+
+
+def setup_monitoring(celery_app: Celery):
+    """
+    Sets up the Celery monitoring thread.
+
+    This function creates a `CeleryMonitoringThread` instance and connects
+    the worker initialization and shutdown signals to start and stop the
+    monitoring thread.
+
+    Args:
+        celery_app: The Celery application instance.
+
+    """
+    monitor_thread = CeleryMonitoringThread(celery_app)
+
+    @worker_init.connect(weak=False)
+    def start_monitoring_thread(**kwargs):
+        """Signal handler to start the monitoring thread when the worker initializes."""
+        logger.info('Starting Celery event monitoring thread.')
+        monitor_thread.start()
+
+    @worker_shutting_down.connect(weak=False)
+    def stop_monitoring_thread(sig, how, exitcode, **kwargs):
+        """Signal handler to stop the monitoring thread when the worker shuts down."""
+        logger.info('Stopping Celery event monitoring thread.')
+        monitor_thread.stop()

--- a/backend/src/core_worker/signal_handlers.py
+++ b/backend/src/core_worker/signal_handlers.py
@@ -19,13 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 @after_setup_task_logger.connect
-def setup_task_logger(task_logger, *_args, **_kwargs):
+def setup_task_logger(logger, *_args, **_kwargs):
     """
     Configures the task logger format.
 
     See: https://celery.school/custom-celery-task-logger
     """
-    for handler in task_logger.handlers:
+    for handler in logger.handlers:
         handler.setFormatter(
             TaskFormatter('%(asctime)s - %(task_id)s - %(task_name)s - %(name)s - %(levelname)s - %(message)s')
         )

--- a/backend/src/core_worker/tasks.py
+++ b/backend/src/core_worker/tasks.py
@@ -6,12 +6,15 @@ from core import ingest_documents, reset_worker_data
 from log_config_monitor import dump_logger_tree
 
 from . import celeryconfig
+from .event_handlers import setup_monitoring
 
 logger = logging.getLogger(__name__)
 celery_app = Celery(main=__name__)
 
 # Load the configuration from the celeryconfig module
 celery_app.config_from_object(celeryconfig)
+
+setup_monitoring(celery_app)
 
 
 @celery_app.task(name='ingest-docs')

--- a/backend/src/sim_auth_app/models.py
+++ b/backend/src/sim_auth_app/models.py
@@ -9,8 +9,7 @@ import uuid
 from enum import StrEnum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
+from pydantic import BaseModel
 
 
 #

--- a/backend/src/sim_auth_app/sim_create_jwt.py
+++ b/backend/src/sim_auth_app/sim_create_jwt.py
@@ -66,7 +66,11 @@ def _create_access_token(
 
 
 def _create_refresh_token(
-    *, userid: uuid.UUID, username: str, expires_in: Optional[timedelta] = None, additional_claims: Optional[dict] = None
+    *,
+    userid: uuid.UUID,
+    username: str,
+    expires_in: Optional[timedelta] = None,
+    additional_claims: Optional[dict] = None,
 ) -> str:
     """Simulates an actual token creation inside an true authentication service."""
     to_encode = {'sub': userid.urn}


### PR DESCRIPTION
After the API server receives an ingestion request and before the Celery worker starts injecting, the document(s) selected for ingestion should be in the queued state.

This PR repairs the Celery event monitor so that the queued state can be tracked. The queued state starts when the Celery broker has received the task into its broker's queue.