### PR TITLE
centralized logging

### DIFF
--- a/common.compose.yml
+++ b/common.compose.yml
@@ -4,6 +4,7 @@ include:
   - frontend/compose.yml
   - grafana/compose.yml
   - jaeger/compose.yml
+  - loki/compose.yml
   - minio/compose.yml
   - opensearch/compose.yml
   - otel-collector/compose.yml

--- a/loki/compose.yml
+++ b/loki/compose.yml
@@ -1,0 +1,20 @@
+services:
+  # Loki - Centralized Logging
+  loki:
+    image: grafana/loki:3.5
+    profiles: [loki, infrastructure, telemetry, all]
+    ports:
+      - "23100:3100"
+    volumes:
+      - ./local-config.yml:/etc/loki/local-config.yml
+    command:
+      - -config.file=/etc/loki/local-config.yml
+    networks:
+      - agent-poc
+
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s

--- a/loki/local-config.yml
+++ b/loki/local-config.yml
@@ -1,0 +1,62 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  metric_aggregation_enabled: true
+  volume_enabled: true
+
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# Enable reporting, comment the following lines:
+analytics:
+  reporting_enabled: false

--- a/otel-collector/compose.yml
+++ b/otel-collector/compose.yml
@@ -1,7 +1,7 @@
 services:
   # OpenTelemetry Collector - Central telemetry collection and processing
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.111.0
+    image: otel/opentelemetry-collector-contrib:0.130.0
     profiles: [infrastructure, telemetry, all]
 
     ports:
@@ -17,11 +17,12 @@ services:
       - agent-poc
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml
-      - otel-logs-1:/tmp  # For file exporter
+      ## - /mnt/bindfs/docker-containers-bindfs:/var/lib/docker/containers:ro
+      ## - /var/run/docker.sock:/var/run/docker.sock:ro
 
     environment:
       OTEL_ENVIRONMENT: development
-      POD_NAME: otel-collector-1
+      POD_NAME: otel-collector
     command: ["--config=/etc/otelcol-contrib/otel-collector-config.yaml"]
 
     # NOTE:
@@ -36,6 +37,37 @@ services:
     #   retries: 3
     #   start_period: 10s
 
-volumes:
-  otel-logs-1:
-    driver: local
+
+  # OpenTelemetry Collector - Central telemetry collection and processing
+  otel-collector-docker:
+    image: otel/opentelemetry-collector-contrib:0.130.0
+    profiles: [infrastructure, telemetry, all]
+
+    # ports:
+    #   - "8888:8888"   # Collector's own metrics
+    #   - "9411:9411"   # Zipkin receiver
+    #   - "13133:13133" # Health check endpoint
+    networks:
+      - agent-poc
+    volumes:
+      - ./otel-collector-docker-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    environment:
+      OTEL_ENVIRONMENT: development
+      POD_NAME: otel-collector-docker
+    user: "0"
+    command: ["--config=/etc/otelcol-contrib/otel-collector-config.yaml"]
+
+    # NOTE:
+    # The official contrib image is based on the "scratch" image. It copies only the
+    # otel-collector; it does not copy wget or curl into this image. Hence a healthcheck
+    # cannot be defined yet.
+    #
+    # healthcheck:
+    #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:13133/"]
+    #   interval: 10s
+    #   timeout: 5s
+    #   retries: 3
+    #   start_period: 10s

--- a/otel-collector/otel-collector-config.yaml
+++ b/otel-collector/otel-collector-config.yaml
@@ -19,6 +19,12 @@ receivers:
             - "http://*"
             - "https://*"
 
+  # Raw TCP
+  tcplog/docker:
+    listen_address: "0.0.0.0:2255"
+    add_attributes: true     # adds net.peer.ip, etc.[52]
+    one_log_per_packet: false
+
   # Zipkin receiver for applications sending Zipkin-formatted traces
   zipkin:
     endpoint: 0.0.0.0:9411
@@ -31,12 +37,12 @@ receivers:
         scrape_interval: 30s
         scrape_timeout: 10s
       scrape_configs:
-        # FastAPI application metrics
-        - job_name: 'fastapi-integration-server'
-          static_configs:
-            - targets: ['fastapi-integration-server:8100']
-          metrics_path: /metrics
-          scrape_interval: 15s
+        # # FastAPI application metrics
+        # - job_name: 'fastapi-integration-server'
+        #   static_configs:
+        #     - targets: ['fastapi-integration-server:8100']
+        #   metrics_path: /metrics
+        #   scrape_interval: 15s
 
         # # FastAPI application metrics
         # - job_name: 'fastapi-dev-server'
@@ -107,9 +113,9 @@ processors:
     timeout: 1s
     send_batch_max_size: 512
   batch/logs:
-    send_batch_size: 1024
-    timeout: 5s
-    send_batch_max_size: 2048
+    send_batch_size: 1
+    timeout: 1s
+    send_batch_max_size: 1024
 
   # Resource processor to add common attributes
   resource:
@@ -154,10 +160,15 @@ exporters:
     tls:
       insecure: true
 
+  otlphttp/logs:
+    endpoint: "http://loki:3100/otlp"
+    tls:
+      insecure: true
+
   # Debug exporter for traces
   debug/traces:
     # verbosity: basic, normal, or detailed
-    verbosity: detailed
+    verbosity: basic
     sampling_initial: 5
     sampling_thereafter: 200
 
@@ -199,14 +210,6 @@ service:
 
     # Logs pipeline (if needed)
     logs:
-      receivers: [otlp]
-      processors: [memory_limiter, resource, attributes, batch/logs]
-      exporters: [debug/logs]
-
-  # Telemetry configuration for the collector itself
-  telemetry:
-    logs:
-      level: "info"
-    metrics:
-      address: 0.0.0.0:8888
-      level: basic
+      receivers: [otlp, tcplog/docker]
+      processors: [memory_limiter, resource, attributes]
+      exporters: [otlphttp/logs, debug/logs]

--- a/otel-collector/otel-collector-docker-config.yaml
+++ b/otel-collector/otel-collector-docker-config.yaml
@@ -1,0 +1,53 @@
+extensions:
+  docker_observer:
+    # Observes Docker containers and reports them as targets
+    # which the filelog receiver can use for metadata.
+
+receivers:
+  filelog:
+    include: [ /var/lib/docker/containers/*/*-json.log ]
+    # exclude: [ /var/lib/docker/containers/*/*-json.log.* ]
+    include_file_path: true 
+    operators:
+      # Use the new "container" operator. This operator enriches the log messages with some metadata.
+      # See https://opentelemetry.io/blog/2024/otel-collector-container-log-parser/
+      # and https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/container.md
+      - id: container-parser
+        type: container
+        add_metadata_from_filepath: false
+        on_error: send
+      # The "container" operator does not have the capability to attach the compose service name (in a plain Docker environment)
+      # to the log message metadata. Other metadata will still be attached.
+      # 
+      # See https://docs.docker.com/engine/logging/log_tags/
+      - id: extract_metadata_from_docker_tag
+        type: regex_parser
+        parse_from: attributes.attrs.tag
+        regex: '^(?P<name>[^\|]+)\|(?P<image_name>[^\|]+)\|(?P<id>[^$]+)$'
+        if: 'attributes?.attrs?.tag != nil'
+      - type: move
+        from: attributes.name
+        to: resource["container.name"]
+        if: 'attributes?.name != nil'
+      - type: move  
+        from: attributes.image_name
+        to: resource["container.image.name"]
+        if: 'attributes?.image_name != nil'
+      - id: recombine
+        type: recombine
+        combine_field: body
+        is_first_entry: body matches "^(\\[?\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}|\\{\\\")"
+        combine_with: ""
+
+exporters:
+  otlphttp/logs:
+    endpoint: "http://loki:3100/otlp"
+    tls:
+      insecure: true
+
+service:
+  extensions: [docker_observer]
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [otlphttp/logs]

--- a/traefik/dev.compose.yml
+++ b/traefik/dev.compose.yml
@@ -3,7 +3,7 @@ services:
     restart: 'no'
 
     image: 'docker.io/node:22-bookworm-slim'
-    profiles: [ init-volumes, frontend, all ]
+    profiles: [ init-volumes, infrastructure, all ]
 
     # No network is needed to initialize named volumes
     network_mode: none
@@ -31,7 +31,7 @@ services:
 
   traefik:
     image: 'docker.io/traefik:v3.4'
-    profiles: [ frontend, all ]
+    profiles: [ infrastructure, all ]
 
     ports:
       - '15170:15170'

--- a/traefik/test.compose.yml
+++ b/traefik/test.compose.yml
@@ -3,7 +3,7 @@ services:
     restart: 'no'
 
     image: 'docker.io/node:22-bookworm-slim'
-    profiles: [ init-volumes, frontend-test, all ]
+    profiles: [ init-volumes, infrastructure, all ]
 
     # No network is needed to initialize named volumes
     network_mode: none
@@ -32,7 +32,7 @@ services:
 
   traefik-integration:
     image: 'docker.io/traefik:v3.4'
-    profiles: [ frontend-test, all ]
+    profiles: [ infrastructure, all ]
 
     ports:
       - '15180:15180'


### PR DESCRIPTION
Adds centralized logging.

Features:
* The host docker engine is used as a log source. The docker daemon must be configured to add a custom tag to each docker log message.
* The main OpenTelemetryCollector service has a new endpoint to receive log events.
* A second OpenTelemetryCollector service is specifically designated for pulling logs from the host's Docker engine. The 2nd service runs with container root (contrarily to general security principles) because it needs access to the Docker engine's UNIX socket and the raw log directories. In the future, we will see if we can transition to non-root.
* Loki is the central log store and engine
* Grafana is the UI for Loki.