### PR TITLE
rename opensearch container

### DIFF
--- a/opensearch/compose.yml
+++ b/opensearch/compose.yml
@@ -35,7 +35,6 @@ services:
     #     condition: service_completed_successfully
 
     image: opensearchproject/opensearch:2.9.0
-    container_name: opensearch
     hostname: opensearch
     profiles:
       - infrastructure-core


### PR DESCRIPTION
Rename the opensearch container to align with naming conventions.

The name is seen in the Grafana UI for centralized logging.
