### PR TITLE
increase resiliency in guards

### DIFF
--- a/backend/libs/core/src/core/agent/rag_graph/document_retriever.py
+++ b/backend/libs/core/src/core/agent/rag_graph/document_retriever.py
@@ -83,6 +83,13 @@ def query_documents(state: GraphState):
 
     documents = [_clean_up_retrieved(x) for x in documents]
 
+    def _contains_content(doc: Document) -> bool:
+        """Return True when the Document's page_content contains non-whitespace characters."""
+        content = getattr(doc, "page_content", "") or ""
+        return content.strip() != ""
+
+    documents = [x for x in documents if _contains_content(x)]
+
     logger.info('---RETRIEVED %d DOCUMENTS---', len(documents))
 
     for idx, doc in enumerate(documents):

--- a/backend/libs/core/src/core/agent/rag_graph/input_guard.py
+++ b/backend/libs/core/src/core/agent/rag_graph/input_guard.py
@@ -30,7 +30,16 @@ def check_input_with_nemo(state: GraphState):
 
     result = execute_nemo_guardrails_check('input_check', [{'role': 'user', 'content': question}])
 
-    triggered_rail = result['output_data']['triggered_input_rail']
+    # Guard against missing keys. If 'output_data' or 'triggered_input_rail' are missing,
+    # treat as if no rail was triggered (same behavior as triggered_rail == False).
+    triggered_rail = False
+    try:
+        output_data = result.get('output_data') if isinstance(result, dict) else None
+        if isinstance(output_data, dict):
+            triggered_rail = bool(output_data.get('triggered_input_rail', False))
+    except Exception:
+        # If any unexpected structure is returned, default to False to preserve previous behavior.
+        triggered_rail = False
 
     return {'nemo_input_check': 100 if triggered_rail else 0}
 
@@ -53,7 +62,7 @@ def check_input_with_presidio(state: GraphState):
     result = execute_presidio_check(question)
 
     result = [x for x in result if x.get('score', 0.0) < 0.2]
-    result = [x for x in result if x.get('entity_type') not in ['PERSON', 'LOCATION', 'DATE_TIME']]
+    result = [x for x in result if x.get('entity_type', None) not in ['PERSON', 'LOCATION', 'DATE_TIME']]
 
     violation_score = len(result)
 

--- a/backend/libs/core/src/core/agent/rag_graph/nemo_guards.py
+++ b/backend/libs/core/src/core/agent/rag_graph/nemo_guards.py
@@ -13,6 +13,32 @@ def execute_nemo_guardrails_check(config_id: str, messages: list) -> dict:
     openai_api_key = config.open_api_key
     guardrails_url = str(config.nemo_guardrails_url)
 
+    # Validate messages early to avoid calling the external Nemo Guardrails service
+    if not messages:
+        # No messages supplied — return a consistent structure similar to the exception path
+        return {
+            'messages': [
+                {
+                    'role': 'assistant',
+                    'content': 'No input messages provided for content checking.'
+                }
+            ]
+        }
+
+    # Ensure last message has meaningful content
+    last_item = messages[-1]
+    last_content = last_item.get('content', None) if isinstance(last_item, dict) else None
+    if not last_content:
+        # Last message has no content — return without calling Nemo
+        return {
+            'messages': [
+                {
+                    'role': 'assistant',
+                    'content': 'Last message contains no content to check.'
+                }
+            ]
+        }
+
     headers = {
         'Content-Type': 'application/json',
         'Authorization': f'Bearer {openai_api_key}',  # Note: Nemo server can use this for its own OpenAI calls

--- a/backend/libs/core/src/core/agent/rag_graph/presidio_guard.py
+++ b/backend/libs/core/src/core/agent/rag_graph/presidio_guard.py
@@ -11,6 +11,12 @@ def execute_presidio_check(text: str) -> dict:
     """Helper function to call the Presidio server."""
     config = get_lib_config()
     presidio_analyzer_url = str(config.presidio_analyzer_url)
+    # If text is empty or only whitespace, skip the external call and return
+    # an empty result immediately. This avoids unnecessary network calls
+    # and prevents sending invalid payloads to the Presidio analyzer.
+    if not text or not str(text).strip():
+        logger.debug('empty or whitespace-only text received; returning empty result')
+        return {}
 
     payload = {'text': text, 'language': 'en'}
     try:

--- a/backend/libs/core/src/core/agent/rag_graph/response_guard.py
+++ b/backend/libs/core/src/core/agent/rag_graph/response_guard.py
@@ -32,7 +32,18 @@ def check_output_with_nemo(state: GraphState):
     messages = [{'role': 'user', 'content': question}, {'role': 'assistant', 'content': generation}]
     result = execute_nemo_guardrails_check('output_check', messages)
 
-    triggered_rail = result['output_data']['triggered_output_rail']
+    # Safely extract nested keys. If the expected structure isn't present,
+    # treat it as if no rail was triggered (same behavior as triggered_rail == False).
+    triggered_rail = False
+    try:
+        output_data = result.get('output_data') if isinstance(result, dict) else None
+        if isinstance(output_data, dict):
+            # Use get to avoid KeyError if 'triggered_output_rail' is missing
+            triggered_rail = bool(output_data.get('triggered_output_rail', False))
+        else:
+            logger.debug('Nemo result missing "output_data" or it is not a dict: %s', type(output_data))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception('Error parsing nemo guardrails result: %s', exc)
 
     return {'nemo_output_check': 100 if triggered_rail else 0}
 
@@ -54,7 +65,7 @@ def check_output_with_presidio(state: GraphState):
     result = execute_presidio_check(generation)
 
     result = [x for x in result if x.get('score', 0.0) < 0.2]
-    result = [x for x in result if x.get('entity_type') not in ['PERSON', 'LOCATION', 'DATE_TIME']]
+    result = [x for x in result if x.get('entity_type', None) not in ['PERSON', 'LOCATION', 'DATE_TIME']]
 
     violation_score = len(result)
 

--- a/backend/libs/core/src/core/agent/rag_graph/retrieval_guard.py
+++ b/backend/libs/core/src/core/agent/rag_graph/retrieval_guard.py
@@ -39,7 +39,18 @@ def check_retrieval_with_nemo(state: GraphState):
 
         result = execute_nemo_guardrails_check('content_check', [{'role': 'user', 'content': docs_content}])
 
-        triggered_rail = result['output_data']['triggered_input_rail']
+        # Some nemo responses may not include the expected keys. Handle missing
+        # 'output_data' or 'triggered_input_rail' by treating them as False so
+        # the returned scores match the behavior when triggered_rail is False.
+        triggered_rail = False
+        try:
+            if isinstance(result, dict):
+                output_data = result.get('output_data')
+                if isinstance(output_data, dict):
+                    triggered_rail = bool(output_data.get('triggered_input_rail', False))
+        except Exception:
+            # Be conservative: if anything unexpected happens, treat as not triggered
+            triggered_rail = False
 
         scores[index] = 100 if triggered_rail else 0
 
@@ -75,7 +86,7 @@ def check_retrieval_with_presidio(state: GraphState):
         result = execute_presidio_check(docs_content)
 
         result = [x for x in result if x.get('score', 0.0) < 0.2]
-        result = [x for x in result if x.get('entity_type') not in ['PERSON', 'LOCATION', 'DATE_TIME']]
+        result = [x for x in result if x.get('entity_type', None) not in ['PERSON', 'LOCATION', 'DATE_TIME']]
 
         violation_score = len(result)
         scores[index] = 100 if violation_score else 0


### PR DESCRIPTION
The background is that an older version of presidio-analyzer would get stuck in an infinite loop when the supplied text was empty.

This change generalizes the issue to not call presidio-analyzer or nemo-guardrails when the content is empty or whitespace only. This reduces the local GPU demands (presidio-analyzer) and the cloud LLM costs (nemo-guardrails) for the cases of applying guards to obviously useless content.

Also, this change improves the resiliency against scenarios where the guards have unexpected results. When expected keys are missing in the result's schema, this change will gracefully handle it rather than unravelling the LangChain processing.