### PR TITLE
fix nfs docker conflict

### DIFF
--- a/backend/libs/core_db/tests/conftest.py
+++ b/backend/libs/core_db/tests/conftest.py
@@ -1,10 +1,5 @@
+# The conftest.py file provides fixtures for an entire directory.
+# Import fixture modules so pytest will register fixtures defined in them
+# (for example: tests/fixtures/api.py defines `api_server`).
 
-import pytest
-import asyncio
-from backend.libs.core_db.tests.fixtures.db import *
 
-@pytest.fixture(scope="module")
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2117,6 +2117,7 @@ dependencies = [
     { name = "alembic-postgresql-enum" },
     { name = "alembic-utils" },
     { name = "core-db" },
+    { name = "nest-asyncio" },
     { name = "sqlalchemy-utils" },
 ]
 
@@ -2126,6 +2127,7 @@ requires-dist = [
     { name = "alembic-postgresql-enum", specifier = ">=1.7.0" },
     { name = "alembic-utils", specifier = ">=0.8.6" },
     { name = "core-db", editable = "libs/core_db" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "sqlalchemy-utils", specifier = ">=0.42.0" },
 ]
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,35 +5,38 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 export default defineConfig({
-  server: {
-    allowedHosts: [
-      'webui-server',
-      'webui-server-autotest'
+    server: {
+        watch: {
+            usePolling: true,
+        },
+        allowedHosts: [
+            'webui-server',
+            'webui-server-autotest'
+        ],
+    },
+    plugins: [
+        vue({
+            template: {
+                compilerOptions: {
+                    isCustomElement: (tag) =>
+                        [
+                            'field',
+                            'block',
+                            'category',
+                            'xml',
+                            'mutation',
+                            'value',
+                            'sep',
+                            'shadow',
+                        ].includes(tag),
+                }
+            }
+        }),
+        vueDevTools(),
     ],
-  },
-  plugins: [
-    vue({
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) =>
-            [
-              'field',
-              'block',
-              'category',
-              'xml',
-              'mutation',
-              'value',
-              'sep',
-              'shadow',
-            ].includes(tag),
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url))
         }
-      }
-    }),
-    vueDevTools(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
     }
-  }
 })

--- a/services/api-server/build/Dockerfile
+++ b/services/api-server/build/Dockerfile
@@ -144,7 +144,12 @@ RUN \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
     && apt-get install -y sudo \
-    && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,nfsvers=4 0 0" >> /etc/fstab \
+    #
+    # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
+    # This module has a broken "Spare Read" features that failes on Docker / overlay2.
+    # The NFS client is forced into 4.1 protocol which does not support the failing READ_PLUS.
+    #
+    && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/backend-nfs /app/backend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/backend-nfs' >> /etc/sudoers \

--- a/services/api-server/build/cuda12.Dockerfile
+++ b/services/api-server/build/cuda12.Dockerfile
@@ -234,7 +234,12 @@ USER root
 RUN apt-get update \
     && apt-get install -y sudo \
     && mkdir -p /mnt/backend-nfs \
-    && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,nfsvers=4 0 0" >> /etc/fstab \
+    #
+    # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
+    # This module has a broken "Spare Read" features that failes on Docker / overlay2.
+    # The NFS client is forced into 4.1 protocol which does not support the failing READ_PLUS.
+    #
+    && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/backend-nfs /app/backend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/backend-nfs' >> /etc/sudoers \

--- a/services/api-server/config/custom-docker-entrypoint.sh
+++ b/services/api-server/config/custom-docker-entrypoint.sh
@@ -7,6 +7,10 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     sudo /usr/bin/mount /mnt/backend-nfs
     sudo /usr/bin/mount /app/backend
 
+    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
+    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    sleep 2
+
     # Ensure directory exists before mounting
     mkdir -p /app/backend/.venv
     # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 
@@ -24,7 +28,7 @@ fi
 
 cd /app/backend
 
-if [ "${USE_NFS_SRC_DIR:-false}" = "true" || "${USE_LOCAL_VENV_DIR:-false}" = "true" ]; then
+if [ "${USE_NFS_SRC_DIR:-false}" = "true" ] || [ "${USE_LOCAL_VENV_DIR:-false}" = "true" ]; then
     #    
     # Create the virtual environment only once.
     #
@@ -37,13 +41,32 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" || "${USE_LOCAL_VENV_DIR:-false}" = "t
     fi
 
     # Sync the virtual environment (persistent across restarts now)
+    # Use --frozen to prevent writing to the lockfile (which might be read-only or owned by another user)
+    SYNC_CMD="uv sync --frozen --dev --all-packages"
+
+    SYNC_CMD="uv sync --frozen --dev --all-packages"
+    EXTRA_ARGS=""
+
     if [ "$GPU_MODE" == "cuda12" ]; then
-        uv sync  --extra cuda12 --dev --all-packages
+        EXTRA_ARGS="--extra cuda12"
     elif [ "$GPU_MODE" == "cpu" ]; then
-        uv sync  --extra cpu --dev --all-packages
+        EXTRA_ARGS="--extra cpu"
     else
         echo "Unknown GPU_MODE: $GPU_MODE"
         exit -1
+    fi
+
+    set +e
+    # shellcheck disable=SC2086
+    $SYNC_CMD $EXTRA_ARGS
+    EXIT_CODE=$?
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Error: Failed to sync virtual environment."
+        echo "This is likely because uv.lock is not up-to-date with pyproject.toml."
+        echo "Please run 'uv lock' on your host machine to update uv.lock."
+        exit $EXIT_CODE
     fi
 fi
 

--- a/services/api-server/config/run_api_server.sh
+++ b/services/api-server/config/run_api_server.sh
@@ -22,12 +22,29 @@ source .venv/bin/activate
 
 # NOTE: Run compile_requirements.sh after changes to dependencies
 #
+SYNC_CMD="uv sync --frozen --dev --all-packages"
+EXTRA_ARGS=""
+
 if [ "$GPU_MODE" == "cuda12" ]; then
-    uv sync  --extra cuda12 --dev --all-packages
+    EXTRA_ARGS="--extra cuda12"
 elif [ "$GPU_MODE" == "cpu" ]; then
-    uv sync  --extra cpu --dev --all-packages
+    EXTRA_ARGS="--extra cpu"
 else
+    echo "Unknown GPU_MODE: $GPU_MODE"
     exit -1
+fi
+
+set +e
+# shellcheck disable=SC2086
+$SYNC_CMD $EXTRA_ARGS
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Error: Failed to sync virtual environment."
+    echo "This is likely because uv.lock is not up-to-date with pyproject.toml."
+    echo "Please run 'uv lock' on your host machine to update uv.lock."
+    exit $EXIT_CODE
 fi
 
 # Run the FastAPI server.
@@ -59,6 +76,7 @@ fi
 
 uv run --frozen --no-sync \
     watchmedo auto-restart \
+        --debug-force-polling \
         --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
         --directory=./apps --directory=./libs  --recursive --pattern='*.py' \
     -- \

--- a/services/api-server/config/run_automated_test.sh
+++ b/services/api-server/config/run_automated_test.sh
@@ -20,12 +20,29 @@ fi
 
 # NOTE: Run compile_requirements.sh after changes to dependencies
 #
+SYNC_CMD="uv sync --frozen --dev --all-packages"
+EXTRA_ARGS=""
+
 if [ "$GPU_MODE" == "cuda12" ]; then
-    uv sync  --extra cuda12 --dev --all-packages
+    EXTRA_ARGS="--extra cuda12"
 elif [ "$GPU_MODE" == "cpu" ]; then
-    uv sync  --extra cpu --dev --all-packages
+    EXTRA_ARGS="--extra cpu"
 else
+    echo "Unknown GPU_MODE: $GPU_MODE"
     exit -1
+fi
+
+set +e
+# shellcheck disable=SC2086
+$SYNC_CMD $EXTRA_ARGS
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Error: Failed to sync virtual environment."
+    echo "This is likely because uv.lock is not up-to-date with pyproject.toml."
+    echo "Please run 'uv lock' on your host machine to update uv.lock."
+    exit $EXIT_CODE
 fi
 
 # Run the integration tests.
@@ -63,6 +80,7 @@ fi
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debug-force-polling \
    --no-restart-on-command-exit \
    --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
    --directory=./apps --directory=./libs  --recursive --pattern='*.py' \

--- a/services/api-server/config/run_automated_test.sh
+++ b/services/api-server/config/run_automated_test.sh
@@ -77,6 +77,10 @@ if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
     WATCH_DEBOUNCE_SECS=20.0
 fi
 
+df -h
+ls ./libs
+cat ./libs/core_db/tests/conftest.py
+
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -161,6 +161,7 @@ services:
 
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cpu'
     profiles: [ backend-autotest, automated-test, all ]
+    privileged: true
 
     environment:
       DEBUGGER_LISTEN: true
@@ -190,7 +191,7 @@ services:
       - backend-autotest-init-signal-1:/init-signal
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
-      ##SRC - ../config/run_automated_test.sh:/run_automated_test.sh:ro
+      - ../config/run_automated_test.sh:/run_automated_test.sh:ro
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       ##SRC - backend-autotest-home-4:/home/python

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -109,7 +109,7 @@ services:
       ##SRC - ../config/run_api_server.sh:/run_api_server.sh:ro
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
-      ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       ##SRC - backend-autotest-home-1:/home/python
       ##SRC - backend-autotest-venv-1:/app/backend/.venv
       - backend-autotest-staging-1:/staging
@@ -160,7 +160,7 @@ services:
         condition: service_completed_successfully
 
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cpu'
-    profiles: [ automated-test, all ]
+    profiles: [ backend-autotest, automated-test, all ]
 
     environment:
       DEBUGGER_LISTEN: true
@@ -177,6 +177,9 @@ services:
       ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
       ##
       GPU_MODE: cpu
+      ##
+      ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
+      ##
       # Mount the NFS directory into this container
       USE_NFS_SRC_DIR: true
     env_file:
@@ -187,7 +190,7 @@ services:
       - backend-autotest-init-signal-1:/init-signal
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
-      - ../config/run_automated_test.sh:/run_automated_test.sh:ro
+      ##SRC - ../config/run_automated_test.sh:/run_automated_test.sh:ro
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       ##SRC - backend-autotest-home-4:/home/python

--- a/services/celery-worker/config/custom-docker-entrypoint.sh
+++ b/services/celery-worker/config/custom-docker-entrypoint.sh
@@ -7,6 +7,10 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     sudo /usr/bin/mount /mnt/backend-nfs
     sudo /usr/bin/mount /app/backend
 
+    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
+    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    sleep 2
+
     # Ensure directory exists before mounting
     mkdir -p /app/backend/.venv
     # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 

--- a/services/celery-worker/config/run_celery_flower.sh
+++ b/services/celery-worker/config/run_celery_flower.sh
@@ -59,6 +59,7 @@ fi
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debug-force-polling \
    --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
    --directory=./apps --directory=./libs  --recursive --pattern='*.py' \
    -- \

--- a/services/celery-worker/config/run_celery_worker.sh
+++ b/services/celery-worker/config/run_celery_worker.sh
@@ -74,6 +74,7 @@ fi
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \
+   --debug-force-polling \
    --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
    --directory=./apps --directory=./libs  --recursive --pattern='*.py' \
    -- \

--- a/services/dev-server/build/Dockerfile
+++ b/services/dev-server/build/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
     && apt-get install -y sudo \
-    && echo "nfs:/exports /mnt/data nfs defaults,noauto,nfsvers=4 0 0" >> /etc/fstab \
+    && echo "nfs:/exports /mnt/data nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/data /app none defaults,bind,noauto 0 0" >> /etc/fstab \
     # Bind mount .venv and node_modules from user home to /app subdirectories
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \

--- a/services/dev-server/build/cuda12.Dockerfile
+++ b/services/dev-server/build/cuda12.Dockerfile
@@ -40,7 +40,7 @@ RUN \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
     && apt-get install -y sudo \
-    && echo "nfs:/exports /mnt/data nfs defaults,noauto,nfsvers=4 0 0" >> /etc/fstab \
+    && echo "nfs:/exports /mnt/data nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/data /app none defaults,bind,noauto 0 0" >> /etc/fstab \
     # Bind mount .venv and node_modules from user home to /app subdirectories
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \

--- a/services/dev-server/config/custom-docker-entrypoint.sh
+++ b/services/dev-server/config/custom-docker-entrypoint.sh
@@ -24,6 +24,10 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     echo "Bind mounting /mnt/data to /app..."
     sudo mount /app
 
+    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
+    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    sleep 2
+
     # Bind mount .venv from /home/python/.venv-storage
     echo "Bind mounting .venv..."
     sudo mount /app/backend/.venv

--- a/services/nfs/build/Dockerfile
+++ b/services/nfs/build/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    nfs-ganesha nfs-common nfs-ganesha-vfs unison \
+    nfs-ganesha nfs-common nfs-ganesha-vfs unison supervisor psmisc procps net-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the configuration from the named build stage or image `config-dir`.

--- a/services/nfs/build/Dockerfile
+++ b/services/nfs/build/Dockerfile
@@ -4,9 +4,9 @@ FROM debian:12-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    nfs-ganesha nfs-common nfs-ganesha-vfs \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+    nfs-ganesha nfs-common nfs-ganesha-vfs unison \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the configuration from the named build stage or image `config-dir`.
 # The original build uses a sibling stage/image providing the file.

--- a/services/nfs/config/docker-entrypoint.sh
+++ b/services/nfs/config/docker-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-apt update
-apt-get install -y psmisc net-tools
-
 echo "=== NFS Ganesha Entrypoint Diagnostics ==="
 echo "Checking /exports..."
 ls -ld /exports
@@ -23,26 +20,16 @@ echo ""
 mkdir -p /var/run/dbus
 dbus-daemon --system --fork
 
-echo "Starting rpcbind..."
-rpcbind
+mkdir -p /var/log/supervisor
 
-echo "Starting Unison Sync (Background)..."
-# Initial sync from Staging -> Exports to ensure export is populated
+echo "Performing initial sync..."
+# Initial sync from Staging -> Exports to ensure export is populated before starting services
 if [ -d "/staging" ]; then
     echo "Initializing /exports from /staging..."
     unison -batch -owner -group -numericids /staging /exports || echo "Initial sync warning"
-    
-    # Background loop
-    (
-        while true; do
-            # Sync /staging <-> /exports bi-directionally
-            unison -batch -auto -owner -group -numericids /staging /exports > /dev/null 2>&1
-            sleep 1
-        done
-    ) &
 else
     echo "WARN: /staging directory not found. Unison sync skipped."
 fi
 
-echo "Starting ganesha.nfsd..."
-exec ganesha.nfsd "$@"
+echo "Starting Supervisord..."
+exec supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/services/nfs/config/docker-entrypoint.sh
+++ b/services/nfs/config/docker-entrypoint.sh
@@ -26,5 +26,23 @@ dbus-daemon --system --fork
 echo "Starting rpcbind..."
 rpcbind
 
+echo "Starting Unison Sync (Background)..."
+# Initial sync from Staging -> Exports to ensure export is populated
+if [ -d "/staging" ]; then
+    echo "Initializing /exports from /staging..."
+    unison -batch -owner -group -numericids /staging /exports || echo "Initial sync warning"
+    
+    # Background loop
+    (
+        while true; do
+            # Sync /staging <-> /exports bi-directionally
+            unison -batch -auto -owner -group -numericids /staging /exports > /dev/null 2>&1
+            sleep 1
+        done
+    ) &
+else
+    echo "WARN: /staging directory not found. Unison sync skipped."
+fi
+
 echo "Starting ganesha.nfsd..."
 exec ganesha.nfsd "$@"

--- a/services/nfs/config/ganesha.conf
+++ b/services/nfs/config/ganesha.conf
@@ -1,3 +1,7 @@
+# FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
+# This module has a broken "Spare Read" features that failes on Docker / overlay2.
+# The NFS client is forced into 4.1 protocol which does not support the failing READ_PLUS.
+
 NFS_CORE_PARAM {
     Protocols = 4;
     Enable_UDP = False;
@@ -11,18 +15,30 @@ NFS_KRB5 {
     Active_krb5 = false;
 }
 
+NFSV4 {
+    Grace_Period = 0;
+    Domain = localdomain;
+    # Allow numeric UIDs to pass through without trying to map to user@domain
+    # This is critical for Docker environments!
+    Allow_Numeric_Owners = true;
+    Only_Numeric_Owners = true;
+}
+
 EXPORT {
     Export_Id = 100;
     Path = /exports;
     Pseudo = /exports;
     Access_Type = RW;
     Squash = No_Root_Squash;
+    SecType = sys;
 
     Protocols = 4;
     Transports = TCP;
 
     FSAL {
         Name = VFS;
+        Disable_Open_By_Handle = true;
+        Link_Support = false;
     }
 
     CLIENT {
@@ -38,12 +54,15 @@ EXPORT {
     Pseudo = /backend;
     Access_Type = RW;
     Squash = No_Root_Squash;
+    SecType = sys;
 
     Protocols = 4;
     Transports = TCP;
 
     FSAL {
         Name = VFS;
+        Disable_Open_By_Handle = true;
+        Link_Support = false;
     }
 
     CLIENT {
@@ -59,12 +78,15 @@ EXPORT {
     Pseudo = /frontend;
     Access_Type = RW;
     Squash = No_Root_Squash;
+    SecType = sys;
 
     Protocols = 4;
     Transports = TCP;
 
     FSAL {
         Name = VFS;
+        Disable_Open_By_Handle = true;
+        Link_Support = false;
     }
 
     CLIENT {
@@ -76,4 +98,8 @@ EXPORT {
 
 LOG {
     Default_Log_Level = DEBUG;
+    Components {
+        FSAL = FULL_DEBUG;
+        NFS4 = FULL_DEBUG;
+    }
 }

--- a/services/nfs/config/ganesha.conf
+++ b/services/nfs/config/ganesha.conf
@@ -99,7 +99,7 @@ EXPORT {
 LOG {
     Default_Log_Level = DEBUG;
     Components {
-        FSAL = FULL_DEBUG;
-        NFS4 = FULL_DEBUG;
+        FSAL = DEBUG;
+        NFS4 = DEBUG;
     }
 }

--- a/services/nfs/config/supervisord.conf
+++ b/services/nfs/config/supervisord.conf
@@ -1,0 +1,38 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[program:rpcbind]
+command=/sbin/rpcbind -f
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:ganesha]
+command=/usr/bin/ganesha.nfsd -F -L /dev/stdout
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+# Ganesha needs to run after rpcbind.
+# Supervisord doesn't strictly support dependency ordering, but starting rpcbind first usually works or ganesha retries.
+# A small sleep in command or using priority could help if needed, but standard autorestart handles it.
+
+[program:unison]
+# -repeat 1 makes unison poll every 1 second.
+# -batch prevents interactive questions.
+# -auto automatically accepts non-conflicting changes.
+# -owner -group -numericids ensures permissions are preserved.
+command=/usr/bin/unison -batch -repeat 1 -auto -owner -group -numericids /staging /exports
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/services/nfs/deploy/compose.yml
+++ b/services/nfs/deploy/compose.yml
@@ -16,8 +16,8 @@ services:
         volumes:
             - ../config/docker-entrypoint.sh:/docker-entrypoint.sh:ro
             - ../config/ganesha.conf:/etc/ganesha/ganesha.conf:ro
-            # Bind mount the root of this repository into the export directory of the NFS server.
-            - ../../../:/exports/
+            # Bind mount the root of this repository into the staging directory for Unison sync
+            - ../../../:/staging/
 
         cap_add:
             - SYS_ADMIN

--- a/services/nfs/deploy/compose.yml
+++ b/services/nfs/deploy/compose.yml
@@ -16,6 +16,7 @@ services:
         volumes:
             - ../config/docker-entrypoint.sh:/docker-entrypoint.sh:ro
             - ../config/ganesha.conf:/etc/ganesha/ganesha.conf:ro
+            - ../config/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf:ro
             # Bind mount the root of this repository into the staging directory for Unison sync
             - ../../../:/staging/
 

--- a/services/webui-server/build/Dockerfile
+++ b/services/webui-server/build/Dockerfile
@@ -80,7 +80,12 @@ USER root
 #   sudo mount /app/frontend
 RUN apt-get update \
     && apt-get install -y sudo \
-    && echo "nfs:/frontend /mnt/frontend-nfs nfs defaults,noauto 0 0" >> /etc/fstab \
+    #
+    # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
+    # This module has a broken "Spare Read" features that failes on Docker / overlay2.
+    # The NFS client is forced into 4.1 protocol which does not support the failing READ_PLUS.
+    #
+    && echo "nfs:/frontend /mnt/frontend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/frontend-nfs /app/frontend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/node/node_modules-storage /app/frontend/node_modules none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/frontend-nfs' >> /etc/sudoers \

--- a/services/webui-server/config/custom-docker-entrypoint.sh
+++ b/services/webui-server/config/custom-docker-entrypoint.sh
@@ -22,6 +22,10 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 
     # Actually, simpler to just try mount.
     sudo /usr/bin/mount /app/frontend/node_modules
+
+    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
+    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    sleep 2
 fi
 
 cd /app/frontend

--- a/services/webui-server/config/run_webui_server.sh
+++ b/services/webui-server/config/run_webui_server.sh
@@ -12,7 +12,19 @@ export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
 
 
 # Install dependencies
-npm install
+# Use npm ci to ensure we strictly follow package-lock.json and do not attempt to write to it.
+# This prevents permission errors if package-lock.json is read-only or owned by another user.
+set +e
+npm ci
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Error: npm ci failed."
+    echo "This is likely because package-lock.json is not up-to-date with package.json."
+    echo "Please run 'npm install' on your host machine to update package-lock.json."
+    exit $EXIT_CODE
+fi
 
 # Start the Vite (Vue.js) development server
 npm run dev -- --host 0.0.0.0 --logLevel info


### PR DESCRIPTION
There is a conflict between NFS v4.2 and Docker's overlay2 file system.

This leads to using Ganesha against a regular Linux file system. To support the `nfs` service's use-case, the bind-mounted file system is 2-way synchronized to an internal regular file system. This is done using `unison` launched on a 1-second cycle by `supervisord`.

Then there is a 2nd problem: Within Ganesha's implementation of the VFS FSAL, which is the only FSAL that supports standard Linux file systems, the NFS-exported files' contents turn to all NUL's. It seems to be isolated to the implementation of the NFS v4.2 protocol where there is an optimization to not transmit long runs of NUL's in the original file.  The non-NUL bytes of a file into all NUL's when using NFS v4.2 but not when using v4.1.

Given that the NFS FSAL is the only suitable FSAL, the two options were to switch to a different NFS server or to downgrade to NFS V4.1. The NFS clients (frontend and backend) were downgraded. The downgrade is by explicitly specifying V4.1 in the `/etc/fstab` of these NFS clients.
