### PR TITLE
merge volume initialization containers into main containers

### DIFF
--- a/services/api-server/build/Dockerfile
+++ b/services/api-server/build/Dockerfile
@@ -14,8 +14,10 @@ RUN \
     ca-certificates \
     curl \
     gnupg \
+    gosu \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* ; \
+    gosu nobody true ; \
     set -eux ; \
     #
     # Create a custom group with GROUP_ID
@@ -87,6 +89,7 @@ RUN \
 # See: https://docs.docker.com/reference/dockerfile/#destination-1
 
 COPY --from=config-dir ./custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
 COPY --from=config-dir ./run_api_server.sh /run_api_server.sh
 
 COPY --from=celery-config-dir ./run_celery_worker.sh /run_celery_worker.sh
@@ -96,10 +99,12 @@ COPY --from=dependency-gate-dir ./wait_for_gate.sh /
 COPY --from=dependency-gate-dir ./wait_for_resource.sh /
 
 RUN chmod a+x /custom-docker-entrypoint.sh \
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
     && chmod a+x /run_celery_worker.sh \
     && chmod a+x /run_celery_flower.sh \
     && chmod a+x /run_api_server.sh \
     && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_celery_worker.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_celery_flower.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_api_server.sh \
@@ -163,7 +168,6 @@ RUN \
     set -eux ; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
-    && apt-get install -y sudo \
     #
     # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
     # This module has a broken "Spare Read" features that failes on Docker / overlay2.
@@ -172,12 +176,6 @@ RUN \
     && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/backend-nfs /app/backend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/backend-nfs' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /mnt/backend-nfs' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend/.venv' >> /etc/sudoers \
     && mkdir -p /mnt/backend-nfs \
     && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
     && rm -rf /var/lib/apt/lists/*

--- a/services/api-server/build/cuda12.Dockerfile
+++ b/services/api-server/build/cuda12.Dockerfile
@@ -177,8 +177,9 @@ RUN \
 # a directory, the destination must end with a trailing slash.
 # See: https://docs.docker.com/reference/dockerfile/#destination-1
 
-COPY --from=config-dir ./custom-docker-entrypoint.sh /
-COPY --from=config-dir ./run_api_server.sh /
+COPY --from=config-dir ./custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+COPY --from=config-dir ./run_api_server.sh /run_api_server.sh
 COPY --from=celery-config-dir ./run_celery_worker.sh /
 COPY --from=celery-config-dir ./run_celery_flower.sh /
 
@@ -186,10 +187,12 @@ COPY --from=dependency-gate-dir ./wait_for_gate.sh /
 COPY --from=dependency-gate-dir ./wait_for_resource.sh /
 
 RUN chmod a+x /custom-docker-entrypoint.sh \
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
     && chmod a+x /run_celery_worker.sh \
     && chmod a+x /run_celery_flower.sh \
     && chmod a+x /run_api_server.sh \
     && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_celery_worker.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_celery_flower.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_api_server.sh \
@@ -247,7 +250,6 @@ USER root
 # The user will run the following command:
 #   sudo mount /app/backend
 RUN apt-get update \
-    && apt-get install -y sudo \
     && mkdir -p /mnt/backend-nfs \
     #
     # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
@@ -257,12 +259,6 @@ RUN apt-get update \
     && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/backend-nfs /app/backend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/backend-nfs' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /mnt/backend-nfs' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend/.venv' >> /etc/sudoers \
     && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
     && rm -rf /var/lib/apt/lists/*
 

--- a/services/api-server/build/cuda12.Dockerfile
+++ b/services/api-server/build/cuda12.Dockerfile
@@ -17,8 +17,10 @@ RUN \
     ca-certificates \
     curl \
     gnupg \
+    gosu \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* ; \
+    gosu nobody true ; \
     #
     # Create a custom group with GROUP_ID
     # Then create a custom user with USER_ID and GROUP_ID and home directory.

--- a/services/api-server/build/python_bookworm_cuda11.Dockerfile
+++ b/services/api-server/build/python_bookworm_cuda11.Dockerfile
@@ -22,13 +22,15 @@ ENV NV_CUDA_CUDART_VERSION=11.8.89-1
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg2 \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    gosu \
     && apt-get clean \
+    && gosu nobody true \
     && curl -fsSL --proto "=https" --proto-redir "=https" \
-        https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/3bf863cc.pub \
-        | apt-key add - \
+    https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/3bf863cc.pub \
+    | apt-key add - \
     && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64 /" > /etc/apt/sources.list.d/cuda.list \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
@@ -37,8 +39,8 @@ RUN \
     #
     apt-get update \
     && apt-get install -y --no-install-recommends \
-        cuda-compat-11-8 \
-        cuda-cudart-11-8=${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-11-8 \
+    cuda-cudart-11-8=${NV_CUDA_CUDART_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     # Required for nvidia-docker v1
@@ -115,22 +117,22 @@ RUN apt-get update \
     # Install the CUDA libraries installed in the runtime NVIDIA image.
     #
     && apt-get install -y --no-install-recommends \
-        cuda-libraries-11-8=${NV_CUDA_LIB_VERSION} \
-        cuda-nvtx-11-8=${NV_NVTX_VERSION} \
-        libcublas-11-8=${NV_LIBCUBLAS_VERSION} \
-        libcusparse-11-8=${NV_LIBCUSPARSE_VERSION} \
-        libnpp-11-8=${NV_LIBNPP_VERSION} \
+    cuda-libraries-11-8=${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-11-8=${NV_NVTX_VERSION} \
+    libcublas-11-8=${NV_LIBCUBLAS_VERSION} \
+    libcusparse-11-8=${NV_LIBCUSPARSE_VERSION} \
+    libnpp-11-8=${NV_LIBNPP_VERSION} \
     #
     # Install the CUDNN libraries installed in the runtime NVIDIA image.
     #
     # See: https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.3/ubuntu2404/runtime/cudnn/Dockerfile
     #
-        libcudnn8=${NV_CUDNN_VERSION} \
-   && apt-get clean \
-   && apt-mark hold \
-        libcublas-11-8 \
-        libcudnn8 \
-   && rm -rf /var/lib/apt/lists/*
+    libcudnn8=${NV_CUDNN_VERSION} \
+    && apt-get clean \
+    && apt-mark hold \
+    libcublas-11-8 \
+    libcudnn8 \
+    && rm -rf /var/lib/apt/lists/*
 #        libnccl2=${NV_LIBNCCL_PACKAGE_VERSION} \
 #   && apt-mark hold libcublas-11-8 libnccl2 \
 #

--- a/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -eu
+
+# Note: NFS and venv mounts are now handled by the root entrypoint
+
+cd /app/backend
+
+if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
+    #    
+    # Create the virtual environment only once.
+    #
+    # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
+    # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
+    if [ ! -f ".venv/CACHEDIR.TAG" ] \
+        || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
+    then
+        uv venv --allow-existing
+    fi
+
+    # Sync the virtual environment (persistent across restarts now)
+    # Use --frozen to prevent writing to the lockfile (which might be read-only or owned by another user)
+    SYNC_CMD="uv sync --frozen --dev --all-packages"
+
+    SYNC_CMD="uv sync --frozen --dev --all-packages"
+    EXTRA_ARGS=""
+
+    if [ "$GPU_MODE" == "cuda12" ]; then
+        EXTRA_ARGS="--extra cuda12"
+    elif [ "$GPU_MODE" == "cpu" ]; then
+        EXTRA_ARGS="--extra cpu"
+    else
+        echo "Unknown GPU_MODE: $GPU_MODE"
+        exit -1
+    fi
+
+    set +e
+    # shellcheck disable=SC2086
+    $SYNC_CMD $EXTRA_ARGS
+    EXIT_CODE=$?
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Error: Failed to sync virtual environment."
+        echo "This is likely because uv.lock is not up-to-date with pyproject.toml."
+        echo "Please run 'uv lock' on your host machine to update uv.lock."
+        exit $EXIT_CODE
+    fi
+fi
+
+ls -la .
+
+source .venv/bin/activate
+
+exec "$@"

--- a/services/api-server/config/custom-docker-entrypoint.sh
+++ b/services/api-server/config/custom-docker-entrypoint.sh
@@ -1,77 +1,46 @@
-set -eu
+#!/usr/bin/env bash
 
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# Volume initialization logic (must run as root)
+echo "Initializing backend volumes..."
+
+# NFS mounting logic (if requested)
 if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
-    # If running with NFS, we need to mask node_modules with a tmpfs so it's container-local
     echo "Running in NFS mode. Mounting file systems..."
-    # The command must exactly match what is permitted in the /etc/sudoers file to avoid execution denial.
-    sudo /usr/bin/mount /mnt/backend-nfs
-    sudo /usr/bin/mount /app/backend
+    # These mounts require root privileges
+    mount /mnt/backend-nfs || echo "Warning: Failed to mount /mnt/backend-nfs"
+    mount /app/backend || echo "Warning: Failed to mount /app/backend"
 
-    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
-    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    # Wait for the NFS server/sync loop
     sleep 2
 
-    # Ensure directory exists before mounting
     mkdir -p /app/backend/.venv
-    # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 
-    # Actually, simpler to just try mount.
-    sudo /usr/bin/mount /app/backend/.venv
+    mount /app/backend/.venv || echo "Warning: Failed to mount /app/backend/.venv"
 fi
 
-if [ "${USE_LOCAL_VENV_DIR:-false}" = "true" ]; then
-    # Ensure directory exists before mounting
-    #mkdir -p /app/backend/.venv
-    # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 
-    # Actually, simpler to just try mount.
-    sudo /usr/bin/mount /app/backend/.venv
-fi
+# Identify potential volume mount points in the backend containers
+# API Server volumes
+API_VOLS="/app/backend/.venv /staging"
 
-cd /app/backend
-
-if [ "${USE_NFS_SRC_DIR:-false}" = "true" ] || [ "${USE_LOCAL_VENV_DIR:-false}" = "true" ]; then
-    #    
-    # Create the virtual environment only once.
-    #
-    # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
-    # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
-    if [ ! -f ".venv/CACHEDIR.TAG" ] \
-        || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
-    then
-        uv venv --allow-existing
-    fi
-
-    # Sync the virtual environment (persistent across restarts now)
-    # Use --frozen to prevent writing to the lockfile (which might be read-only or owned by another user)
-    SYNC_CMD="uv sync --frozen --dev --all-packages"
-
-    SYNC_CMD="uv sync --frozen --dev --all-packages"
-    EXTRA_ARGS=""
-
-    if [ "$GPU_MODE" == "cuda12" ]; then
-        EXTRA_ARGS="--extra cuda12"
-    elif [ "$GPU_MODE" == "cpu" ]; then
-        EXTRA_ARGS="--extra cpu"
+for VOL in $API_VOLS
+do
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      chown -R 1000:1000 "$VOL"
+      chmod -R 755 "$VOL"
+      ls -ld "$VOL"
     else
-        echo "Unknown GPU_MODE: $GPU_MODE"
-        exit -1
+      echo "$VOL is already initialized."
     fi
+  fi
+done
 
-    set +e
-    # shellcheck disable=SC2086
-    $SYNC_CMD $EXTRA_ARGS
-    EXIT_CODE=$?
-    set -e
 
-    if [ $EXIT_CODE -ne 0 ]; then
-        echo "Error: Failed to sync virtual environment."
-        echo "This is likely because uv.lock is not up-to-date with pyproject.toml."
-        echo "Please run 'uv lock' on your host machine to update uv.lock."
-        exit $EXIT_CODE
-    fi
-fi
-
-ls -la .
-
-source .venv/bin/activate
-
-exec "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to python (UID 1000)..."
+exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/api-server/config/custom-docker-entrypoint.sh
+++ b/services/api-server/config/custom-docker-entrypoint.sh
@@ -28,14 +28,20 @@ API_VOLS="/app/backend/.venv /staging"
 for VOL in $API_VOLS
 do
   if [ -d "$VOL" ]; then
-    if [ ! -f "$VOL/.initialized" ]; then
-      echo "Initializing $VOL..."
-      touch "$VOL/.initialized"
-      chown -R 1000:1000 "$VOL"
-      chmod -R 755 "$VOL"
-      ls -ld "$VOL"
+    # Only initialize if it's a mount point (volume)
+    # We check /proc/self/mounts as a robust way to identify mounts.
+    if grep -q " $VOL " /proc/self/mounts; then
+      if [ ! -f "$VOL/.initialized" ]; then
+        echo "Initializing $VOL..."
+        touch "$VOL/.initialized"
+        chown -R 1000:1000 "$VOL"
+        chmod -R 755 "$VOL"
+        ls -ld "$VOL"
+      else
+        echo "$VOL is already initialized."
+      fi
     else
-      echo "$VOL is already initialized."
+      echo "$VOL is part of the image, skipping initialization."
     fi
   fi
 done

--- a/services/api-server/config/run_api_server.sh
+++ b/services/api-server/config/run_api_server.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e  # Exit immediately on error.
 set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.

--- a/services/api-server/config/run_build_backend.sh
+++ b/services/api-server/config/run_build_backend.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e  # Exit immediately on error.
 set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -123,7 +123,7 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
     entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
@@ -207,7 +207,7 @@ services:
       - checkpoints_postgres_autotest_secrets
       - redis_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
     entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -29,7 +29,7 @@ services:
       - ../config/run_api_server.sh:/run_api_server.sh:ro
       - backend-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh
-      ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       - backend-staging-1:/staging
     secrets:
       - answers_secrets

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -1,73 +1,5 @@
 services:
-  init-backend-volumes:
-    restart: 'no'
-
-    image: 'docker.io/python:3.12.8-slim-bookworm'
-    profiles: [ init-volumes, api-server, backend, all ]
-
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - backend-home-1:/home/python/home-1
-      - backend-venv-1:/home/python/venv-1
-      - backend-staging-1:/home/python/staging-1
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/python/
-
-        for VOL in \
-          'home-1' 'venv-1' 'staging-1'
-        do
-          touch /home/python/$$VOL/.initialized
-          chown -R 1000:1000 /home/python/$$VOL
-          chmod -R 755 /home/python/$$VOL
-          ls -ld /home/python/$$VOL
-        done
-
-  backend-dependency-gate:
-    restart: 'no'
-
-    image: localhost/localhost/debian-slim-util:1.0
-    profiles: [ backend,  api-server, infrastructure, all ]
-
-    env_file:
-      - backend.env
-    networks:
-      - agent-poc
-    volumes:
-      - backend-init-signal-1:/init-signal
-      - ../config/run_dependency_gate.sh:/run_dependency_gate.sh:ro
-      - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
-      - ../../dependency-gate/wait_for_resource.sh:/wait_for_resource.sh:ro
-    secrets:
-      - answers_postgres_secrets
-      - answers_seaweedfs_secrets
-      - checkpoints_postgres_secrets
-      - redis_secrets
-      - weaviate_secrets
-
-    mem_limit: 128m
-    memswap_limit: 128m
-    # set shared memory limit when using docker-compose
-    shm_size: 128mb
-    entrypoint: 'bash'
-    command: [ /run_dependency_gate.sh ]
-
-
-
   api-server:
-    depends_on:
-      init-backend-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-backend:python-3.12-cuda12'
     profiles: [  api-server, backend, all ]
 
@@ -109,10 +41,10 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
+    entrypoint: [ '/custom-docker-entrypoint.sh' ]
     command: [ '/run_api_server.sh' ]
     deploy:
       resources:
@@ -126,13 +58,14 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the FastAPI server
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
+      # When this service starts for the first time, it may take several minutes to sync
+      # the python environment and start the FastAPI server. A healthcheck based on
+      # API pinging would fail during this period.
       #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
+      # For now, we verify that python3 is executable.
+      # Note: If switching to an API-based check, use http://127.0.0.1 to avoid
+      # IPv6 resolution issues with 'localhost'.
+      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
       test: ['CMD', 'python3', '--version']
       interval: 30s
       timeout: 15s
@@ -175,11 +108,12 @@ services:
       - ../../../backend:/app/backend
       ## - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh
       - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh
+      - ../config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
+    entrypoint: [ '/custom-docker-entrypoint.sh' ]
     command: [ '/run_build_backend.sh' ]
 
 

--- a/services/celery-worker/config/run_celery_flower.sh
+++ b/services/celery-worker/config/run_celery_flower.sh
@@ -12,7 +12,7 @@ export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
 #
 source /wait_for_gate.sh
 
-wait_for_dependency_gate /init-signal/backend-gate
+##wait_for_dependency_gate /init-signal/backend-gate
 
 if [ "$GPU_MODE" == "cuda12" ]; then
     nvidia-smi

--- a/services/celery-worker/config/run_celery_worker.sh
+++ b/services/celery-worker/config/run_celery_worker.sh
@@ -12,7 +12,7 @@ export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
 #
 source /wait_for_gate.sh
 
-wait_for_dependency_gate /init-signal/backend-gate
+##wait_for_dependency_gate /init-signal/backend-gate
 
 if [ "$GPU_MODE" == "cuda12" ]; then
     nvidia-smi

--- a/services/celery-worker/deploy/common-autotest.compose.yml
+++ b/services/celery-worker/deploy/common-autotest.compose.yml
@@ -51,7 +51,7 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
     entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
@@ -126,7 +126,7 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
     entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]

--- a/services/celery-worker/deploy/common.compose.yml
+++ b/services/celery-worker/deploy/common.compose.yml
@@ -1,44 +1,5 @@
 services:
-  init-celery-volumes:
-    restart: 'no'
-
-    image: 'docker.io/python:3.12.8-slim-bookworm'
-    profiles: [ init-volumes, celery, backend, all ]
-
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - backend-home-2:/home/python/home-2
-      - backend-venv-2:/home/python/venv-2
-      - backend-staging-2:/home/python/staging-2
-      - backend-home-3:/home/python/home-3
-      - backend-venv-3:/home/python/venv-3
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/python/
-
-        for VOL in \
-          'home-2' 'venv-2' 'staging-2' \
-          'home-3' 'venv-3'
-        do
-          touch /home/python/$$VOL/.initialized
-          chown -R 1000:1000 /home/python/$$VOL
-          chmod -R 755 /home/python/$$VOL
-          ls -ld /home/python/$$VOL
-        done
-
   celery-worker:
-    depends_on:
-      init-celery-volumes:
-        condition: service_completed_successfully
 
     image: 'localhost/localhost/answers-backend:python-3.12-cuda12'
     profiles: [  celery, backend, all ]
@@ -82,10 +43,10 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
+    entrypoint: [ '/custom-docker-entrypoint.sh' ]
     command: [ '/run_celery_worker.sh' ]
     deploy:
       resources:
@@ -99,13 +60,14 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the celery worker
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
+      # When this service starts for the first time, it may take several minutes to sync
+      # the python environment and start the service. A healthcheck based on
+      # pinging would fail during this period.
       #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
+      # For now, we verify that python3 is executable.
+      # Note: If switching to a network-based check, use http://127.0.0.1 to avoid
+      # IPv6 resolution issues with 'localhost'.
+      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
       test: ['CMD', 'python3', '--version']
       interval: 30s
       timeout: 15s
@@ -114,9 +76,6 @@ services:
 
           
   celery-flower:
-    depends_on:
-      init-celery-volumes:
-        condition: service_completed_successfully
 
     image: 'localhost/localhost/answers-backend:python-3.12-cpu'
     profiles: [ celery, backend, all ]
@@ -156,20 +115,21 @@ services:
       - redis_secrets
       - weaviate_secrets
 
-    user: '1000:1000'
+    user: root
     # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
     # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
+    entrypoint: [ '/custom-docker-entrypoint.sh' ]
     command: [ '/run_celery_flower.sh' ]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the celery flower node
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
+      # When this service starts for the first time, it may take several minutes to sync
+      # the python environment and start the service. A healthcheck based on
+      # pinging would fail during this period.
       #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
+      # For now, we verify that python3 is executable.
+      # Note: If switching to a network-based check, use http://127.0.0.1 to avoid
+      # IPv6 resolution issues with 'localhost'.
+      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
       test: ['CMD', 'python3', '--version']
       interval: 30s
       timeout: 15s
@@ -212,11 +172,14 @@ services:
       # library's urllib.request module. This script will attempt to connect to
       # the /health endpoint on port 9808 and exit with a status code
       # indicating success (0) or failure (1).
+      #
+      # Use the IPv4 loopback address. When 'localhost' is used, urllib will try to use
+      # the IPv6 ::1 address where there is no listening port.
       test: [
         'CMD',
         'python3',
         '-c',
-        "import urllib.request, sys; sys.exit(0) if urllib.request.urlopen('http://localhost:9808/health').getcode() == 200 else sys.exit(1)"
+        "import urllib.request, sys; sys.exit(0) if urllib.request.urlopen('http://127.0.0.1:9808/health').getcode() == 200 else sys.exit(1)"
       ]
       interval: 30s
       timeout: 15s

--- a/services/dev-server/build/Dockerfile
+++ b/services/dev-server/build/Dockerfile
@@ -26,9 +26,12 @@ RUN --mount=type=bind,from=node-source,target=/context \
 # Copy scripts
 #
 COPY --from=config-dir ./custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
 
 RUN chmod a+x /custom-docker-entrypoint.sh \
-    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -45,22 +48,11 @@ RUN \
     set -eux ; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
-    && apt-get install -y sudo \
     && echo "nfs:/exports /mnt/data nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/data /app none defaults,bind,noauto 0 0" >> /etc/fstab \
     # Bind mount .venv and node_modules from user home to /app subdirectories
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/node_modules-storage /app/frontend/node_modules none defaults,bind,noauto 0 0" >> /etc/fstab \
-    # Sudoers configuration for mounting
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/data' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /mnt/data' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/frontend/node_modules' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/frontend/node_modules' >> /etc/sudoers \
-    && echo 'python ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && mkdir -p /mnt/data \
     && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
     && mkdir -p /home/python/node_modules-storage && chown ${USER_ID}:${GROUP_ID} /home/python/node_modules-storage

--- a/services/dev-server/build/cuda12.Dockerfile
+++ b/services/dev-server/build/cuda12.Dockerfile
@@ -26,9 +26,12 @@ RUN --mount=type=bind,from=node-source,target=/context \
 # Copy scripts
 #
 COPY --from=config-dir ./custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
 
 RUN chmod a+x /custom-docker-entrypoint.sh \
-    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -42,21 +45,11 @@ RUN \
     set -eux ; \
     export DEBIAN_FRONTEND=noninteractive ; \
     apt-get update \
-    && apt-get install -y sudo \
     && echo "nfs:/exports /mnt/data nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/data /app none defaults,bind,noauto 0 0" >> /etc/fstab \
     # Bind mount .venv and node_modules from user home to /app subdirectories
     && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/python/node_modules-storage /app/frontend/node_modules none defaults,bind,noauto 0 0" >> /etc/fstab \
-    # Sudoers configuration for mounting
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/data' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /mnt/data' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/backend/.venv' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/mount /app/frontend/node_modules' >> /etc/sudoers \
-    && echo 'python ALL=(ALL) NOPASSWD: /usr/bin/umount /app/frontend/node_modules' >> /etc/sudoers \
     && mkdir -p /mnt/data \
     && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
     && mkdir -p /home/python/node_modules-storage && chown ${USER_ID}:${GROUP_ID} /home/python/node_modules-storage

--- a/services/dev-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/dev-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+#
+# This entrypoint script is responsible for setting up the environment
+# for the dev-server container.
+#
+
+echo "Starting dev-server entrypoint..."
+
+#
+# Mount the NFS directory if requested
+#
+# Note: NFS and bind mounts are now handled by the root entrypoint
+
+# If backend directory exists, then set up the Python environment.
+if [ -d "/app/backend" ]; then
+    (
+        cd /app/backend
+
+        if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
+            #    
+            # Create the virtual environment only once.
+            #
+            # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
+            # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
+            if [ ! -f ".venv/CACHEDIR.TAG" ] \
+                || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
+            then
+                uv venv --allow-existing
+            fi
+
+            # Sync the virtual environment (persistent across restarts now)
+            if [ "$GPU_MODE" == "cuda12" ]; then
+                uv sync  --extra cuda12 --dev --all-packages
+            elif [ "$GPU_MODE" == "cpu" ]; then
+                uv sync  --extra cpu --dev --all-packages
+            else
+                echo "Unknown GPU_MODE: $GPU_MODE"
+                exit -1
+            fi
+        fi
+
+        ls -la .
+
+        if [ -f .venv/bin/activate ]; then
+            # We source it here to verify it works, but sourcing in a subshell won't affect parent.
+            # So we actually need to replicate the sourcing logic in the parent OR accept that 
+            # the parent environment won't have the venv activated by default unless we do it again.
+            # However, since the user asked if we should return to original directory, the implication 
+            # is they MIGHT want to run commands elsewhere.
+            # But normally we want 'exec "$@"' to run with the venv activated.
+            true
+        else
+            echo "Warning: .venv/bin/activate not found."
+        fi
+    )
+    
+    # Re-activate in parent if available, but keep directory as original (likely /app)
+    if [ -f "/app/backend/.venv/bin/activate" ]; then
+        source /app/backend/.venv/bin/activate
+    fi
+else
+    echo "Directory /app/backend not found. Skipping backend setup."
+fi
+
+# If frontend directory exists, then set up the ViteJS environment.
+if [ -d "/app/frontend" ]; then
+    (
+        cd /app/frontend
+        echo npm install
+    )
+else
+    echo "Directory /app/frontend not found. Skipping frontend setup."
+fi
+
+exec "$@"

--- a/services/dev-server/config/custom-docker-entrypoint.sh
+++ b/services/dev-server/config/custom-docker-entrypoint.sh
@@ -14,10 +14,15 @@ DEV_VOLS="/home/python /home/python/.venv-storage /home/python/node_modules-stor
 for VOL in $DEV_VOLS
 do
   if [ -d "$VOL" ]; then
-    echo "Initializing $VOL..."
-    chown -R 1000:1000 "$VOL"
-    chmod -R 755 "$VOL"
-    ls -ld "$VOL"
+    # Only initialize if it's a mount point (volume)
+    if grep -q " $VOL " /proc/self/mounts; then
+      echo "Initializing $VOL..."
+      chown -R 1000:1000 "$VOL"
+      chmod -R 755 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is part of the image, skipping initialization."
+    fi
   fi
 done
 

--- a/services/dev-server/config/custom-docker-entrypoint.sh
+++ b/services/dev-server/config/custom-docker-entrypoint.sh
@@ -1,103 +1,53 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
 
-#
-# This entrypoint script is responsible for setting up the environment
-# for the dev-server container.
-#
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
-echo "Starting dev-server entrypoint..."
+echo "Initializing dev-server volumes..."
 
-#
-# Mount the NFS directory if requested
-#
+# Identify potential volume mount points
+# The backend and frontend setup will happen in the non-priv script,
+# but we need to ensure the shared volumes are owned by the python user.
+DEV_VOLS="/home/python /home/python/.venv-storage /home/python/node_modules-storage"
+
+for VOL in $DEV_VOLS
+do
+  if [ -d "$VOL" ]; then
+    echo "Initializing $VOL..."
+    chown -R 1000:1000 "$VOL"
+    chmod -R 755 "$VOL"
+    ls -ld "$VOL"
+  fi
+done
+
+# NFS mounting logic (if requested)
 if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     echo "Mounting NFS directory..."
-    # Attempt to mount /mnt/data
     if mountpoint -q /mnt/data; then
         echo "/mnt/data is already mounted."
     else
-        sudo /usr/bin/mount /mnt/data || echo "Failed to mount /mnt/data, proceeding anyway (might be pre-mounted)."
+        mount /mnt/data || echo "Failed to mount /mnt/data"
     fi
 
     # Bind mount /mnt/data to /app
     echo "Bind mounting /mnt/data to /app..."
-    sudo /usr/bin/mount /app
+    mount /app || echo "Failed to mount /app"
 
-    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
-    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    # Wait for the NFS server/sync loop
     sleep 2
 
     # Bind mount .venv from /home/python/.venv-storage
     echo "Bind mounting .venv..."
-    sudo /usr/bin/mount /app/backend/.venv
+    mkdir -p /app/backend/.venv
+    mount /app/backend/.venv || echo "Failed to mount /app/backend/.venv"
 
-    # Bind mount node_modules from /home/python/node_modules-storage
-    # Note: user is python (uid 1000), but node stuff might be in frontend dir.
-    # We mapped node_modules-storage to /app/frontend/node_modules in fstab/dockerfile.
+    # Bind mount node_modules
     echo "Bind mounting node_modules..."
-    sudo /usr/bin/mount /app/frontend/node_modules
+    mkdir -p /app/frontend/node_modules
+    mount /app/frontend/node_modules || echo "Failed to mount /app/frontend/node_modules"
 fi
 
-# If backend directory exists, then set up the Python environment.
-if [ -d "/app/backend" ]; then
-    (
-        cd /app/backend
-
-        if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
-            #    
-            # Create the virtual environment only once.
-            #
-            # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
-            # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
-            if [ ! -f ".venv/CACHEDIR.TAG" ] \
-                || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
-            then
-                uv venv --allow-existing
-            fi
-
-            # Sync the virtual environment (persistent across restarts now)
-            if [ "$GPU_MODE" == "cuda12" ]; then
-                uv sync  --extra cuda12 --dev --all-packages
-            elif [ "$GPU_MODE" == "cpu" ]; then
-                uv sync  --extra cpu --dev --all-packages
-            else
-                echo "Unknown GPU_MODE: $GPU_MODE"
-                exit -1
-            fi
-        fi
-
-        ls -la .
-
-        if [ -f .venv/bin/activate ]; then
-            # We source it here to verify it works, but sourcing in a subshell won't affect parent.
-            # So we actually need to replicate the sourcing logic in the parent OR accept that 
-            # the parent environment won't have the venv activated by default unless we do it again.
-            # However, since the user asked if we should return to original directory, the implication 
-            # is they MIGHT want to run commands elsewhere.
-            # But normally we want 'exec "$@"' to run with the venv activated.
-            true
-        else
-            echo "Warning: .venv/bin/activate not found."
-        fi
-    )
-    
-    # Re-activate in parent if available, but keep directory as original (likely /app)
-    if [ -f "/app/backend/.venv/bin/activate" ]; then
-        source /app/backend/.venv/bin/activate
-    fi
-else
-    echo "Directory /app/backend not found. Skipping backend setup."
-fi
-
-# If frontend directory exists, then set up the ViteJS environment.
-if [ -d "/app/frontend" ]; then
-    (
-        cd /app/frontend
-        echo npm install
-    )
-else
-    echo "Directory /app/frontend not found. Skipping frontend setup."
-fi
-
-exec "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to python (UID 1000)..."
+exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/dev-server/deploy/common.compose.yml
+++ b/services/dev-server/deploy/common.compose.yml
@@ -1,49 +1,9 @@
 services:
-  init-dev-server-volumes:
-    restart: 'no'
-
-    image: 'docker.io/python:3.12.8-slim-bookworm'
-    profiles: [ init-volumes, dev-server, all ]
-
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - dev-server-home:/home/python
-      - dev-server-venv:/home/python/.venv-storage
-      - dev-server-node-modules:/home/python/node_modules-storage
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/python/
-
-        mkdir -p /home/python/.venv-storage
-        mkdir -p /home/python/node_modules-storage
-
-        chown -R 1000:1000 /home/python
-
-        ls -ld /home/python/
-#    secrets:
-#      - answers_minio_autotest_secrets
-#      - answers_postgres_autotest_secrets
-#      - checkpoints_postgres_autotest_secrets
-#      - redis_secrets
-#      - weaviate_secrets
-
   dev-server:
-    depends_on:
-      init-dev-server-volumes:
-        condition: service_completed_successfully
-
     # Image is defined in cpu-only.compose.yml or cuda.compose.yml
     profiles: [ dev-server, all ]
     privileged: true
+    user: root
 
     environment:
       DEBUGGER_LISTEN: true

--- a/services/grafana/deploy/compose.yml
+++ b/services/grafana/deploy/compose.yml
@@ -1,40 +1,41 @@
 services:
-  grafana:
-    restart: unless-stopped
+    grafana:
+        restart: unless-stopped
 
-    profiles: [ grafana, infrastructure, telemetry, all ]
-    image: grafana/grafana:12.1.0
+        profiles: [ grafana, infrastructure, telemetry, all ]
+        image: grafana/grafana:12.1.0
 
-    env_file:
-      - grafana.env
-    volumes:
-      - ../config/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
-      - grafana-data-1:/var/lib/grafana
-      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-    ports:
-      - 23000:3000
-    networks:
-      - agent-poc
-    secrets:
-      - grafana_secrets
+        env_file:
+            - grafana.env
+        volumes:
+            - ../config/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+            - grafana-data-1:/var/lib/grafana
+            - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+        ports:
+            - 23000:3000
+        networks:
+            - agent-poc
+        secrets:
+            - grafana_secrets
 
-    entrypoint: /custom-docker-entrypoint.sh
-    # When entrypoint is specified in the compose file, the CMD in the Dockerfile is
-    # will be ignored. Hence, extract its value and add it here in the compose file:
-    #   docker inspect grafana/grafana | jq '.[0].Config.Cmd'
-    ##command:
+        entrypoint: /custom-docker-entrypoint.sh
+        # When entrypoint is specified in the compose file, the CMD in the Dockerfile is
+        # will be ignored. Hence, extract its value and add it here in the compose file:
+        #   docker inspect grafana/grafana | jq '.[0].Config.Cmd'
+        ##command:
 
 
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/health']
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
-
+        healthcheck:
+            # Use the IPv4 loopback address. When 'localhost' is used, curl will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ 'CMD', 'curl', '-f', 'http://127.0.0.1:3000/api/health' ]
+            interval: 30s
+            timeout: 5s
+            retries: 5
+            start_period: 5s
 
 volumes:
-  grafana-data-1:
-    driver: local
-  grafana-provisioning-1:
-    driver: local
+    grafana-data-1:
+        driver: local
+    grafana-provisioning-1:
+        driver: local

--- a/services/jaeger/deploy/compose.yml
+++ b/services/jaeger/deploy/compose.yml
@@ -1,25 +1,25 @@
 services:
-  # Jaeger - Distributed Tracing
-  jaeger:
-    image: jaegertracing/all-in-one:1.74.0
-    profiles: [jaeger, infrastructure, telemetry, all]
-    ports:
-      - "16686:16686"  # Jaeger UI
-      - "14268:14268"  # Jaeger HTTP collector
-      - "14250:14250"  # Jaeger gRPC collector
-      - "14318:4318"   # OTLP HTTP receiver
-      - "14317:4317"   # OTLP gRPC receiver
-    command:
-      - "--log-level=debug"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:14269/"]
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
-    networks:
-      - agent-poc
-
-
+    # Jaeger - Distributed Tracing
+    jaeger:
+        image: jaegertracing/all-in-one:1.74.0
+        profiles: [ jaeger, infrastructure, telemetry, all ]
+        ports:
+            - "16686:16686" # Jaeger UI
+            - "14268:14268" # Jaeger HTTP collector
+            - "14250:14250" # Jaeger gRPC collector
+            - "14318:4318" # OTLP HTTP receiver
+            - "14317:4317" # OTLP gRPC receiver
+        command:
+            - "--log-level=debug"
+        environment:
+            - COLLECTOR_OTLP_ENABLED=true
+        healthcheck:
+            # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:14269/" ]
+            interval: 30s
+            timeout: 5s
+            retries: 5
+            start_period: 5s
+        networks:
+            - agent-poc

--- a/services/keycloak/config/healthcheck.sh
+++ b/services/keycloak/config/healthcheck.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-exec 3<>/dev/tcp/localhost/9000
-echo -e "GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n" >&3
+exec 3<>/dev/tcp/127.0.0.1/9000
+echo -e "GET /health/ready HTTP/1.1\r\nhost: 127.0.0.1\r\nConnection: close\r\n\r\n" >&3
 grep '"status".*"UP"' <&3

--- a/services/loki/deploy/compose.yml
+++ b/services/loki/deploy/compose.yml
@@ -1,20 +1,22 @@
 services:
-  # Loki - Centralized Logging
-  loki:
-    image: grafana/loki:3.5
-    profiles: [loki, infrastructure, telemetry, all]
-    ports:
-      - "23100:3100"
-    volumes:
-      - ../config/local-config.yml:/etc/loki/local-config.yml:ro
-    command:
-      - -config.file=/etc/loki/local-config.yml
-    networks:
-      - agent-poc
+    # Loki - Centralized Logging
+    loki:
+        image: grafana/loki:3.5
+        profiles: [ loki, infrastructure, telemetry, all ]
+        ports:
+            - "23100:3100"
+        volumes:
+            - ../config/local-config.yml:/etc/loki/local-config.yml:ro
+        command:
+            - -config.file=/etc/loki/local-config.yml
+        networks:
+            - agent-poc
 
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
+        healthcheck:
+            # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3100/" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 5s

--- a/services/nemo/build/build_images.sh
+++ b/services/nemo/build/build_images.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -eu
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 #
 # Build a nemo-guardrails image.
@@ -14,6 +16,9 @@ set -eu
 DOCKER="docker buildx"
 #DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
 
 $DOCKER build \
   --file Dockerfile \
@@ -21,4 +26,5 @@ $DOCKER build \
   --build-context config-dir=../config \
   --tag localhost/localhost/nemo-guardrails:latest \
   --progress plain \
-  . 2>&1
+  . 2>&1 \
+| tee $LOG_DIR/build-nemo.log

--- a/services/nemo/deploy/compose.yml
+++ b/services/nemo/deploy/compose.yml
@@ -1,40 +1,37 @@
 name: nemo
 
 services:
-  nemo-guardrails:
-    restart: unless-stopped
+    nemo-guardrails:
+        restart: unless-stopped
 
-    image: localhost/localhost/nemo-guardrails:latest
-    profiles: [
-      nemo,
-      backend,
-      all
-    ]
+        image: localhost/localhost/nemo-guardrails:latest
+        profiles: [ nemo, backend, all ]
 
-    env_file:
-      - nemo.env
-      - opentelemetry-instrument.env
-    ports:
-      - '27500:8000'
-    networks:
-      - agent-poc
-    volumes:
-      - ../../dist:/dist:ro
-      ##SRC - ../config/config:/config:ro
-      ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-      ##SRC - ../config/docker/pyproject.toml:/app/pyproject.toml
-      ##SRC - ../config/docker/uv.lock:/app/uv.lock:ro
-    secrets:
-      - answers_secrets
+        env_file:
+            - nemo.env
+            - opentelemetry-instrument.env
+        ports:
+            - '27500:8000'
+        networks:
+            - agent-poc
+        volumes:
+            - ../../dist:/dist:ro
+            ##SRC - ../config/config:/config:ro
+            ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+            ##SRC - ../config/docker/pyproject.toml:/app/pyproject.toml
+            ##SRC - ../config/docker/uv.lock:/app/uv.lock:ro
+        secrets:
+            - answers_secrets
 
+        entrypoint: [ '/custom-docker-entrypoint.sh' ]
+        # The option --config=/config is required for multi-config support.
+        command: [ "server", "--config=/config" ]
 
-    entrypoint: [ '/custom-docker-entrypoint.sh' ]
-    # The option --config=/config is required for multi-config support.
-    command: ["server", "--config=/config"]
-
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8000/']
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
+        healthcheck:
+            # Use the IPv4 loopback address. When 'localhost' is used, curl will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ 'CMD', 'curl', '-f', 'http://127.0.0.1:8000/' ]
+            interval: 30s
+            timeout: 5s
+            retries: 5
+            start_period: 5s

--- a/services/nfs/build/build_images.sh
+++ b/services/nfs/build/build_images.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -eu
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 #
 # Build a nfs image.
@@ -14,6 +16,9 @@ set -eu
 DOCKER="docker buildx"
 DOCKER_BUILD_OPTS="--no-cache"
 #DOCKER_BUILD_OPTS=
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
 
 $DOCKER build \
   --file Dockerfile \
@@ -21,4 +26,5 @@ $DOCKER build \
   --build-context config-dir=../config \
   --tag localhost/localhost/nfs:latest \
   --progress plain \
-  . 2>&1
+  . 2>&1 \
+| tee $LOG_DIR/build-nfs.log

--- a/services/opensearch/build/Dockerfile
+++ b/services/opensearch/build/Dockerfile
@@ -1,0 +1,22 @@
+FROM opensearchproject/opensearch:2.17.1
+
+ARG NONPRIV_USER=1000:1000
+
+USER root
+
+# Install gosu. OpenSearch is usually AlmaLinux based.
+RUN yum update -y --allowerasing && \
+    yum install -y --allowerasing ca-certificates curl && \
+    curl -L https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 -o /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+COPY --from=config-dir /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir /custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+
+RUN chmod +x /custom-docker-entrypoint.sh /custom-docker-entrypoint-nonpriv.sh
+
+ENTRYPOINT ["/custom-docker-entrypoint.sh"]
+CMD ["opensearch"]

--- a/services/opensearch/build/build_images.sh
+++ b/services/opensearch/build/build_images.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+DOCKER="docker build"
+# Use buildx if available for better caching and progress
+if docker buildx version > /dev/null 2>&1; then
+    DOCKER="docker buildx build"
+fi
+
+IMAGE_TAG="localhost/localhost/opensearch:2.17.1-custom"
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
+
+echo "Building ${IMAGE_TAG}..."
+
+$DOCKER \
+    --file Dockerfile \
+    --build-context config-dir=../config \
+    --tag "${IMAGE_TAG}" \
+    --progress plain \
+    --load \
+    . 2>&1 \
+| tee $LOG_DIR/build-opensearch.log
+
+echo "Build complete: ${IMAGE_TAG}"

--- a/services/opensearch/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/opensearch/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# Set environment variables from mounted secrets files
+
+SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
+# shellcheck disable=SC2046
+export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
+
+# Process with original entrypoint, which can be discovered
+# from the host command-line with:
+#   docker inspect opensearchproject/opensearch:2.9.0 | jq '.[0].Config.Entrypoint'
+exec ./opensearch-docker-entrypoint.sh "$@"

--- a/services/opensearch/config/custom-docker-entrypoint.sh
+++ b/services/opensearch/config/custom-docker-entrypoint.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 
-set -e
-set -u
-set -o pipefail
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
-# Set environment variables from mounted secrets files
+# Volume initialization logic (must run as root)
+echo "Initializing volumes..."
+for VOL in /usr/share/opensearch/data
+do
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      chown -R 1000:1000 "$VOL"
+      chmod -R 777 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is already initialized."
+    fi
+  else
+    echo "Warning: Volume directory $VOL not found."
+  fi
+done
 
-SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
-# shellcheck disable=SC2046
-export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
-
-# Process with original entrypoint, which can be discovered
-# from the host command-line with:
-#   docker inspect opensearchproject/opensearch:2.9.0 | jq '.[0].Config.Entrypoint'
-exec ./opensearch-docker-entrypoint.sh "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to 1000:1000..."
+exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/opensearch/deploy/compose.yml
+++ b/services/opensearch/deploy/compose.yml
@@ -1,84 +1,53 @@
 services:
-  init-opensearch-volumes:
-    restart: 'no'
+    opensearch:
+        restart: unless-stopped
+        image: localhost/localhost/opensearch:2.17.1-custom
+        hostname: opensearch
+        profiles:
+            - opensearch
+            - infrastructure-core
+            - infrastructure
+            - all
 
-    image: 'docker.io/debian:bookworm-slim'
-    profiles: [ init-volumes, opensearch, infrastructure-core, infrastructure, all ]
+        ports:
+            - "29200:9200" # HTTP
+            - "29600:9600" # Transport
+        networks:
+            - agent-poc
+        volumes:
+            - opensearch-data-1:/usr/share/opensearch/data
+        secrets:
+            - opensearch_secrets
 
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - opensearch-data-1:/data-1
+        user: root
+        entrypoint: /custom-docker-entrypoint.sh
+        command: [ "opensearch" ]
 
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
+        env_file:
+            - ./opensearch.env
+        environment:
+            # For simpler dev setup, security plugin is disabled.
+            # If enabled, OPENSEARCH_INITIAL_ADMIN_PASSWORD from secrets will be used by the image's entrypoint.
+            DISABLE_SECURITY_PLUGIN: "true"
 
-        for VOL in 'data-1'
-        do
-          touch /$$VOL/.initialized
-          chown -R 1000:1000 /$$VOL
-          chmod -R 777 /$$VOL
-          ls -ld /$$VOL
-        done
+        healthcheck:
+            # Use the IPv4 loopback address. When 'localhost' is used, curl will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ "CMD-SHELL", "curl -s --fail http://127.0.0.1:9200/_cluster/health || exit 1" ]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 60s # OpenSearch can take a while to start
 
-
-  opensearch:
-    restart: unless-stopped
-    # depends_on:
-    #   init-opensearch-volumes: # If an init-volumes service were added
-    #     condition: service_completed_successfully
-
-    image: opensearchproject/opensearch:2.17.1
-    hostname: opensearch
-    profiles:
-      - opensearch
-      - infrastructure-core
-      - infrastructure
-      - all
-
-    ports:
-      - "29200:9200" # HTTP
-      - "29600:9600" # Transport
-    networks:
-      - agent-poc
-    volumes:
-      - opensearch-data-1:/usr/share/opensearch/data
-      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-    secrets:
-      - opensearch_secrets
-
-    user: '1000:1000'
-    entrypoint: /custom-docker-entrypoint.sh
-    command: [ "opensearch" ]
-
-    env_file:
-      - ./opensearch.env
-    environment:
-      # For simpler dev setup, security plugin is disabled.
-      # If enabled, OPENSEARCH_INITIAL_ADMIN_PASSWORD from secrets will be used by the image's entrypoint.
-      DISABLE_SECURITY_PLUGIN: "true"
-
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s --fail http://localhost:9200/_cluster/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s # OpenSearch can take a while to start
-
-    ulimits: # Recommended for OpenSearch
-      memlock:
-        soft: 65536
-        hard: 65536
-      nofile:
-        soft: 65536
-        hard: 65536
+        ulimits:
+            # Recommended for OpenSearch
+            memlock:
+                soft: 65536
+                hard: 65536
+            nofile:
+                soft: 65536
+                hard: 65536
 
 volumes:
-  opensearch-data-1:
-    driver: local
+    opensearch-data-1:
+        driver: local

--- a/services/otel-collector/deploy/compose.yml
+++ b/services/otel-collector/deploy/compose.yml
@@ -1,73 +1,75 @@
 services:
-  # OpenTelemetry Collector - Central telemetry collection and processing
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.142.0
-    profiles: [infrastructure, telemetry, all]
+    # OpenTelemetry Collector - Central telemetry collection and processing
+    otel-collector:
+        image: otel/opentelemetry-collector-contrib:0.142.0
+        profiles: [ infrastructure, telemetry, all ]
 
-    ports:
-      - "4317:4317"   # OTLP gRPC receiver
-      - "4318:4318"   # OTLP HTTP receiver
-      - "8889:8889"   # Prometheus metrics exporter
-      - "8888:8888"   # Collector's own metrics
-      - "9411:9411"   # Zipkin receiver
-      - "13133:13133" # Health check endpoint
-      - "1777:1777"   # pprof endpoint
-      - "55679:55679" # zpages endpoint
-    networks:
-      - agent-poc
-    volumes:
-      - ../config/otel-collector-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml:ro
-      ## - /mnt/bindfs/docker-containers-bindfs:/var/lib/docker/containers:ro
-      ## - /var/run/docker.sock:/var/run/docker.sock:ro
+        ports:
+            - "4317:4317" # OTLP gRPC receiver
+            - "4318:4318" # OTLP HTTP receiver
+            - "8889:8889" # Prometheus metrics exporter
+            - "8888:8888" # Collector's own metrics
+            - "9411:9411" # Zipkin receiver
+            - "13133:13133" # Health check endpoint
+            - "1777:1777" # pprof endpoint
+            - "55679:55679" # zpages endpoint
+        networks:
+            - agent-poc
+        volumes:
+            - ../config/otel-collector-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml:ro
+            ## - /mnt/bindfs/docker-containers-bindfs:/var/lib/docker/containers:ro
+            ## - /var/run/docker.sock:/var/run/docker.sock:ro
 
-    environment:
-      OTEL_ENVIRONMENT: development
-      POD_NAME: otel-collector
-    command: ["--config=/etc/otelcol-contrib/otel-collector-config.yaml"]
+        environment:
+            OTEL_ENVIRONMENT: development
+            POD_NAME: otel-collector
+        command: [ "--config=/etc/otelcol-contrib/otel-collector-config.yaml" ]
+        # NOTE:
+        # The official contrib image is based on the "scratch" image. It copies only the
+        # otel-collector; it does not copy wget or curl into this image. Hence a healthcheck
+        # cannot be defined yet.
+        #
+        # healthcheck:
+        #   # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+        #   # the IPv6 ::1 address where there is no listening port.
+        #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:13133/"]
+        #   interval: 30s
+        #   timeout: 5s
+        #   retries: 3
+        #   start_period: 10s
 
-    # NOTE:
-    # The official contrib image is based on the "scratch" image. It copies only the
-    # otel-collector; it does not copy wget or curl into this image. Hence a healthcheck
-    # cannot be defined yet.
-    #
-    # healthcheck:
-    #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:13133/"]
-    #   interval: 30s
-    #   timeout: 5s
-    #   retries: 3
-    #   start_period: 10s
 
+        # OpenTelemetry Collector - Central telemetry collection and processing
+    otel-collector-docker:
+        image: otel/opentelemetry-collector-contrib:0.142.0
+        profiles: [ infrastructure, telemetry, all ]
 
-  # OpenTelemetry Collector - Central telemetry collection and processing
-  otel-collector-docker:
-    image: otel/opentelemetry-collector-contrib:0.142.0
-    profiles: [infrastructure, telemetry, all]
+        # ports:
+        #   - "8888:8888"   # Collector's own metrics
+        #   - "9411:9411"   # Zipkin receiver
+        #   - "13133:13133" # Health check endpoint
+        networks:
+            - agent-poc
+        volumes:
+            - ../config/otel-collector-docker-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml:ro
+            - /var/lib/docker/containers:/var/lib/docker/containers:ro
+            - /var/run/docker.sock:/var/run/docker.sock:ro
 
-    # ports:
-    #   - "8888:8888"   # Collector's own metrics
-    #   - "9411:9411"   # Zipkin receiver
-    #   - "13133:13133" # Health check endpoint
-    networks:
-      - agent-poc
-    volumes:
-      - ../config/otel-collector-docker-config.yaml:/etc/otelcol-contrib/otel-collector-config.yaml:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-
-    environment:
-      OTEL_ENVIRONMENT: development
-      POD_NAME: otel-collector-docker
-    user: "0"
-    command: ["--config=/etc/otelcol-contrib/otel-collector-config.yaml"]
-
-    # NOTE:
-    # The official contrib image is based on the "scratch" image. It copies only the
-    # otel-collector; it does not copy wget or curl into this image. Hence a healthcheck
-    # cannot be defined yet.
-    #
-    # healthcheck:
-    #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:13133/"]
-    #   interval: 30s
-    #   timeout: 5s
-    #   retries: 3
-    #   start_period: 10s
+        environment:
+            OTEL_ENVIRONMENT: development
+            POD_NAME: otel-collector-docker
+        user: "0"
+        command: [ "--config=/etc/otelcol-contrib/otel-collector-config.yaml" ]
+        # NOTE:
+        # The official contrib image is based on the "scratch" image. It copies only the
+        # otel-collector; it does not copy wget or curl into this image. Hence a healthcheck
+        # cannot be defined yet.
+        #
+        # healthcheck:
+        #   # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+        #   # the IPv6 ::1 address where there is no listening port.
+        #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:13133/"]
+        #   interval: 30s
+        #   timeout: 5s
+        #   retries: 3
+        #   start_period: 10s

--- a/services/postgres/build/docker/build_images.sh
+++ b/services/postgres/build/docker/build_images.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -eu
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 #
 # Build the customized Postgres image with the pgvector extension.
@@ -12,9 +14,14 @@ set -eu
 
 # DOCKER=podman
 DOCKER="docker buildx"
+LOG_DIR=../../../../logs
+
+mkdir -p $LOG_DIR
 
 $DOCKER build \
   --build-context parent-dir=.. \
   --file Dockerfile \
   --tag localhost/localhost/postgres:17.2-with-pgvector \
-  .
+  --progress plain \
+  . 2>&1 \
+| tee $LOG_DIR/build-postgres.log

--- a/services/prometheus/deploy/compose.yml
+++ b/services/prometheus/deploy/compose.yml
@@ -1,87 +1,87 @@
 services:
 
-  prometheus:
-    restart: unless-stopped
+    prometheus:
+        restart: unless-stopped
 
-    image: prom/prometheus:v3.4.2
-    profiles: [ prometheus, infrastructure, telemetry, all ]
+        image: prom/prometheus:v3.4.2
+        profiles: [ prometheus, infrastructure, telemetry, all ]
 
-    ports:
-      - 29090:9090
-    networks:
-      - agent-poc
-    volumes:
-      - ../config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - ../config/alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
-      - prometheus-data-1:/prometheus
-      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+        ports:
+            - 29090:9090
+        networks:
+            - agent-poc
+        volumes:
+            - ../config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+            - ../config/alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+            - prometheus-data-1:/prometheus
+            - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
 
-    entrypoint: [ '/bin/sh',  '/custom-docker-entrypoint.sh' ]
-    # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
-    # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=30d'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    mem_limit: 512m
-    memswap_limit: 1g
+        entrypoint: [ '/bin/sh', '/custom-docker-entrypoint.sh' ]
+        # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
+        # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
+        command:
+            - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--storage.tsdb.path=/prometheus'
+            - '--storage.tsdb.retention.time=30d'
+            - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+            - '--web.console.templates=/usr/share/prometheus/consoles'
+            - '--web.enable-lifecycle'
+        mem_limit: 512m
+        memswap_limit: 1g
 
-    healthcheck:
-      test:
-        # The prom/prometheus image does not have curl installed. And since the image is based on
-        # busybox, curl is not available.
-        # wget: -q    Turns off wget output, specifically the progress bar.
-        #       -S    Shows the server response, which includes the HTTP status code.
-        #       -O -  Writes the content to stdout.
-        # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
-        - CMD-SHELL
-        - >-
-          wget -qS -O - http://localhost:9090/-/healthy 2>&1
-          | grep -q 'HTTP/1.1 200 OK'
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
+        healthcheck:
+            test:
+                # The prom/prometheus image does not have curl installed. And since the image is based on
+                # busybox, curl is not available.
+                # wget: -q    Turns off wget output, specifically the progress bar.
+                #       -S    Shows the server response, which includes the HTTP status code.
+                #       -O -  Writes the content to stdout.
+                # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+                # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+                # the IPv6 ::1 address where there is no listening port.
+                # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+                - CMD-SHELL
+                - >-
+                  wget -qS -O - http://127.0.0.1:9090/-/healthy 2>&1 | grep -q 'HTTP/1.1 200 OK'
+            interval: 30s
+            timeout: 5s
+            retries: 5
+            start_period: 5s
 
-  alertmanager:
-    restart: unless-stopped
+    alertmanager:
+        restart: unless-stopped
 
-    image: prom/alertmanager:v0.28.1
-    profiles: [ prometheus, infrastructure, telemetry, all ]
+        image: prom/alertmanager:v0.28.1
+        profiles: [ prometheus, infrastructure, telemetry, all ]
 
-    ports:
-      - 29093:9093
-    networks:
-      - agent-poc
-    volumes:
-      - ../config/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+        ports:
+            - 29093:9093
+        networks:
+            - agent-poc
+        volumes:
+            - ../config/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
 
-    command:
-      - '--config.file=/etc/alertmanager/alertmanager.yml'
-    mem_limit: 256m
-    memswap_limit: 1g
+        command:
+            - '--config.file=/etc/alertmanager/alertmanager.yml'
+        mem_limit: 256m
+        memswap_limit: 1g
 
-    healthcheck:
-      test:
-        # The prom/prometheus image does not have curl installed. And since the image is based on
-        # busybox, curl is not available.
-        # wget: -q    Turns off wget output, specifically the progress bar.
-        #       -S    Shows the server response, which includes the HTTP status code.
-        #       -O -  Writes the content to stdout.
-        # grep: -q  Quiet. Exit code 0 if PATTERN is found, 1 otherwise
-        - CMD-SHELL
-        - >-
-          wget -qS -O - http://localhost:9093/-/healthy 2>&1
-          | grep -q 'HTTP/1.1 200 OK'
-      interval: 30s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
-
+        healthcheck:
+            test:
+                # The prom/prometheus image does not have curl installed. And since the image is based on
+                # busybox, curl is not available.
+                # wget: -q    Turns off wget output, specifically the progress bar.
+                #       -S    Shows the server response, which includes the HTTP status code.
+                #       -O -  Writes the content to stdout.
+                # grep: -q  Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+                - CMD-SHELL
+                - >-
+                  wget -qS -O - http://localhost:9093/-/healthy 2>&1 | grep -q 'HTTP/1.1 200 OK'
+            interval: 30s
+            timeout: 5s
+            retries: 5
+            start_period: 5s
 
 volumes:
-  prometheus-data-1:
-    driver: local
+    prometheus-data-1:
+        driver: local

--- a/services/redis/build/Dockerfile
+++ b/services/redis/build/Dockerfile
@@ -1,0 +1,22 @@
+FROM redis:7.4.1-bookworm
+
+ARG NONPRIV_USER=redis
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    gosu; \
+    rm -rf /var/lib/apt/lists/*; \
+    # verify that the binary works
+    gosu nobody true
+
+COPY --from=config-dir /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir /custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+
+RUN chmod +x /custom-docker-entrypoint.sh /custom-docker-entrypoint-nonpriv.sh
+
+ENTRYPOINT ["/custom-docker-entrypoint.sh"]
+CMD ["redis-server", "/redis.conf"]

--- a/services/redis/build/build_images.sh
+++ b/services/redis/build/build_images.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+DOCKER="docker build"
+# Use buildx if available for better caching and progress
+if docker buildx version > /dev/null 2>&1; then
+    DOCKER="docker buildx build"
+fi
+
+IMAGE_TAG="localhost/localhost/redis:7.4.1-custom"
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
+
+echo "Building ${IMAGE_TAG}..."
+
+$DOCKER \
+    --file Dockerfile \
+    --build-context config-dir=../config \
+    --tag "${IMAGE_TAG}" \
+    --progress plain \
+    --load \
+    . 2>&1 \
+| tee $LOG_DIR/build-redis.log
+
+echo "Build complete: ${IMAGE_TAG}"

--- a/services/redis/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/redis/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# Set environment variables from mounted secrets files
+
+SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
+# shellcheck disable=SC2046
+export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
+
+sed "s/\${REDIS_DEFAULT_PASSWORD}/${REDIS_DEFAULT_PASSWORD}/g" /redis.conf.template > redis.conf
+
+cat redis.conf
+
+# Process with original entrypoint, which can be discovered
+# from the host command-line with:
+#   docker inspect redis:latest | jq '.[0].Config.Entrypoint'
+exec docker-entrypoint.sh "$@"

--- a/services/redis/config/custom-docker-entrypoint.sh
+++ b/services/redis/config/custom-docker-entrypoint.sh
@@ -4,17 +4,25 @@ set -e  # Exit immediately on error.
 set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
-# Set environment variables from mounted secrets files
+# Volume initialization logic (must run as root)
+echo "Initializing volumes..."
+for VOL in /data
+do
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      chown -R 999:999 "$VOL"
+      chmod -R 777 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is already initialized."
+    fi
+  else
+    echo "Warning: Volume directory $VOL not found."
+  fi
+done
 
-SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
-# shellcheck disable=SC2046
-export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
-
-sed "s/\${REDIS_DEFAULT_PASSWORD}/${REDIS_DEFAULT_PASSWORD}/g" /redis.conf.template > redis.conf
-
-cat redis.conf
-
-# Process with original entrypoint, which can be discovered
-# from the host command-line with:
-#   docker inspect redis:latest | jq '.[0].Config.Entrypoint'
-exec docker-entrypoint.sh "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to redis..."
+exec gosu redis /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/redis/deploy/compose.yml
+++ b/services/redis/deploy/compose.yml
@@ -1,41 +1,9 @@
 name: redis
 
 services:
-    init-redis-volumes:
-        restart: 'no'
-
-        image: 'docker.io/debian:bookworm-slim'
-        profiles: [ init-volumes, redis, infrastructure-core, infrastructure, all ]
-
-        # No network is needed to initialize named volumes
-        network_mode: none
-        volumes:
-            - redis-data-1:/data-1
-
-        entrypoint: 'bash'
-        command:
-            - '-c'
-            # Beware that docker-compose also performs variable interpolation.
-            # So we need to escape the dollar sign with $$name so that bash
-            # will recieve our embedded script with $name. 
-            - |
-              set -ex ;
-
-              for VOL in 'data-1'
-              do
-                touch /$$VOL/.initialized
-                chown -R 999:999 /$$VOL
-                chmod -R 777 /$$VOL
-                ls -ld /$$VOL
-              done
-
     redis:
         restart: unless-stopped
-        depends_on:
-            init-redis-volumes:
-                condition: service_completed_successfully
-
-        image: redis:7.4.1-bookworm
+        image: localhost/localhost/redis:7.4.1-custom
         profiles: [ redis, infrastructure-core, infrastructure, all ]
 
         ports:
@@ -44,12 +12,11 @@ services:
             - agent-poc
         volumes:
             - redis-data-1:/data
-            - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
             - ../config/redis.conf.template:/redis.conf.template:ro
         secrets:
             - redis_secrets
 
-        user: "redis:redis"
+        user: root
         entrypoint: [ '/custom-docker-entrypoint.sh' ]
         # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
         # See: https://docs.docker.com/reference/compose-file/services/#entrypoint

--- a/services/scripts/build_images.sh
+++ b/services/scripts/build_images.sh
@@ -5,7 +5,7 @@ set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 # Build container images.
-for SUBDIR in slim-util api-server webui-server dev-server seaweedfs
+for SUBDIR in slim-util seaweedfs redis opensearch traefik weaviate nfs api-server
 do
     ( cd "$SUBDIR"/build ; ./build_images.sh )
 done
@@ -21,7 +21,7 @@ then
 fi
 
 # Build container images.
-for SUBDIR in nemo
+for SUBDIR in nemo webui-server dev-server
 do
     ( cd "$SUBDIR"/build ; ./build_images.sh )
 done

--- a/services/seaweedfs/build/build_images.sh
+++ b/services/seaweedfs/build/build_images.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 # Change to the directory of this script
 cd "$(dirname "$0")"
 
+LOG_DIR=../../../logs
+mkdir -p $LOG_DIR
+
 # Build the image
 docker buildx build \
     -f Dockerfile \
-    -t localhost/localhost/seaweedfs:latest .
+    -t localhost/localhost/seaweedfs:latest \
+    --progress plain \
+    . 2>&1 \
+| tee $LOG_DIR/build-seaweedfs.log
 
 docker buildx build \
     -f init.Dockerfile \
     --build-context config-dir=../config/ \
-    -t localhost/localhost/init-seaweedfs:latest .
+    -t localhost/localhost/init-seaweedfs:latest \
+    --progress plain \
+    . 2>&1 \
+| tee $LOG_DIR/build-init-seaweedfs.log

--- a/services/seaweedfs/deploy/compose.yml
+++ b/services/seaweedfs/deploy/compose.yml
@@ -40,7 +40,9 @@ services:
         memswap_limit: 4g
 
         healthcheck:
-            test: [ "CMD", "curl", "-f", "http://localhost:9005/" ]
+            # Use the IPv4 loopback address. When 'localhost' is used, curl will try to use
+            # the IPv6 ::1 address where there is no listening port.
+            test: [ "CMD", "curl", "-f", "http://127.0.0.1:9005/" ]
             interval: 10s
             timeout: 5s
             retries: 5

--- a/services/slim-util/build/build_images.sh
+++ b/services/slim-util/build/build_images.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -eu
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 #
 # Build a small Debian image with some utilities installed.
@@ -14,10 +16,15 @@ set -eu
 DOCKER="docker buildx"
 #DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
 
 $DOCKER build \
   --file Dockerfile \
   $DOCKER_BUILD_OPTS \
   --build-context parent-dir=.. \
   --tag localhost/localhost/debian-slim-util:1.0 \
-  . 2>&1
+  --progress plain \
+  . 2>&1 \
+| tee $LOG_DIR/build-slim-util.log

--- a/services/traefik/build/Dockerfile
+++ b/services/traefik/build/Dockerfile
@@ -1,0 +1,20 @@
+FROM traefik:v3.4
+
+ARG NONPRIV_USER=traefik
+
+USER root
+
+# Traefik image is Alpine-based.
+RUN apk add --no-cache gosu || \
+    (apk add --no-cache curl gnupg && \
+    curl -L https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 -o /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true)
+
+COPY --from=config-dir /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir /custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+
+RUN chmod +x /custom-docker-entrypoint.sh /custom-docker-entrypoint-nonpriv.sh
+
+ENTRYPOINT ["/custom-docker-entrypoint.sh"]
+CMD ["traefik"]

--- a/services/traefik/build/build_images.sh
+++ b/services/traefik/build/build_images.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+DOCKER="docker build"
+# Use buildx if available for better caching and progress
+if docker buildx version > /dev/null 2>&1; then
+    DOCKER="docker buildx build"
+fi
+
+IMAGE_TAG="localhost/localhost/traefik:v3.4-custom"
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
+
+echo "Building ${IMAGE_TAG}..."
+
+$DOCKER \
+    --file Dockerfile \
+    --build-context config-dir=../config \
+    --tag "${IMAGE_TAG}" \
+    --progress plain \
+    --load \
+    . 2>&1 \
+| tee $LOG_DIR/build-traefik.log
+
+echo "Build complete: ${IMAGE_TAG}"

--- a/services/traefik/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/traefik/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+## set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+## set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# Let’s Encrypt has rate limits, so always persist the acme.json file to avoid repeated requests.
+touch /acme/acme.json
+chmod 600 /acme/acme.json
+
+echo exec /entrypoint.sh "$@"
+
+# Process with original entrypoint, which can be discovered
+# from the host command-line with:
+#   docker inspect traefik:v3.4 | jq '.[0].Config.Entrypoint'
+exec /entrypoint.sh "$@"

--- a/services/traefik/config/custom-docker-entrypoint.sh
+++ b/services/traefik/config/custom-docker-entrypoint.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env sh
 
-## set -e  # Exit immediately on error.
-set -u  # Unbound variables are errors.
-## set -o pipefail  # Use right-most non-zero exit code from a pipe.
+set -e  # Exit immediately on error.
 
-# Let’s Encrypt has rate limits, so always persist the acme.json file to avoid repeated requests.
-touch /acme/acme.json
-chmod 600 /acme/acme.json
+# Volume initialization logic (must run as root)
+echo "Initializing volumes..."
+for VOL in /acme
+do
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      touch "$VOL/acme.json"
+      chown -R 1000:1000 "$VOL"
+      chmod -R 600 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is already initialized."
+    fi
+  else
+    echo "Warning: Volume directory $VOL not found."
+  fi
+done
 
-echo exec /entrypoint.sh "$@"
-
-# Process with original entrypoint, which can be discovered
-# from the host command-line with:
-#   docker inspect traefik:v3.4 | jq '.[0].Config.Entrypoint'
-exec /entrypoint.sh "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to 1000:1000..."
+exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/traefik/config/dynamic/routes.yml
+++ b/services/traefik/config/dynamic/routes.yml
@@ -3,14 +3,14 @@ http:
     webui-router:
       rule: "Host(`localhost`)"
       entryPoints:
-        - websecure1
+        - websecure
       service: webui-service
       tls: {}
 
     api-router:
       rule: "Host(`localhost`) && PathPrefix(`/api/`)"
       entryPoints:
-        - websecure1
+        - websecure
       service: api-service
       middlewares:
         - strip-api-prefix

--- a/services/traefik/deploy/compose.yml
+++ b/services/traefik/deploy/compose.yml
@@ -1,85 +1,54 @@
 services:
-  init-traefik-volumes:
-    restart: 'no'
+    traefik:
+        image: localhost/localhost/traefik:v3.4-custom
+        profiles: [ traefik, infrastructure, all ]
 
-    image: 'docker.io/node:22-bookworm-slim'
-    profiles: [ init-volumes, traefik, infrastructure, all ]
+        ports:
+            - '15170:15170'
+            - '15173:15173'
+            - '15180:15180'
+            - '15183:15183'
+        networks:
+            - agent-poc
+        volumes:
+            # Local docker engine's UNIX socket
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+            #
+            - ../config/traefik.yml:/etc/traefik/traefik.yml:ro
+            - ../config/dynamic:/etc/traefik/dynamic:ro
+            - ../config/certs:/certs:ro
+            # Let’s Encrypt has rate limits, so always persist the acme.json file to avoid repeated requests
+            - traefik-acme-1:/acme
+        security_opt:
+            - no-new-privileges:true
+        environment:
+            - DOCKER_HOST=unix:///var/run/docker.sock
 
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - traefik-acme-1:/home/node/acme-1
+        user: root
+        entrypoint: [ '/custom-docker-entrypoint.sh' ]
+        # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
+        # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
+        command: [ 'traefik' ]
 
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
+        healthcheck:
+            test:
+                # The traefik image is based on alpine or scratch and does not have curl installed.
+                # In newer versions, it might be based on scratch, but wget is usually available in alpine.
+                # wget: -q    Turns off wget output, specifically the progress bar.
+                #       -S    Shows the server response, which includes the HTTP status code.
+                #       -O -  Writes the content to stdout.
+                # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+                # the IPv6 ::1 address where there is no listening port.
+                # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+                - CMD-SHELL
+                - >-
+                  wget -qS -O - http://127.0.0.1:8082/ping 2>&1 | grep -q 'HTTP/1.1 200 OK'
 
-        ls -ld /home/node/
-
-        for VOL in 'acme-1'
-        do
-          touch /home/node/$$VOL/.initialized
-          chown -R 1000:1000 /home/node/$$VOL
-          chmod -R 600 /home/node/$$VOL
-          ls -ld /home/node/$$VOL
-        done
-
-  traefik:
-    image: 'docker.io/traefik:v3.4'
-    profiles: [ traefik, infrastructure, all ]
-
-    ports:
-      - '15170:15170'
-      - '15173:15173'
-      - '15180:15180'
-      - '15183:15183'
-    networks:
-      - agent-poc
-    volumes:
-      # Local docker engine's UNIX socket
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      #
-      - ../config/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ../config/dynamic:/etc/traefik/dynamic:ro
-      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-      - ../config/certs:/certs:ro
-      # Let’s Encrypt has rate limits, so always persist the acme.json file to avoid repeated requests
-      - traefik-acme-1:/acme
-    security_opt:
-      - no-new-privileges:true
-    environment:
-      - DOCKER_HOST=unix:///var/run/docker.sock
-
-    entrypoint: ['/custom-docker-entrypoint.sh']
-    # Beware: when entrypoint is used in the compose file, the CMD in the Dockerfile is ignored.
-    # See: https://docs.docker.com/reference/compose-file/services/#entrypoint
-    command: ['traefik']
-
-    healthcheck:
-      test:
-        # The langfuse/langfuse image does not have curl installed. And since the image is based on
-        # busybox, curl is not available.
-        # wget: -q    Turns off wget output, specifically the progress bar.
-        #       -S    Shows the server response, which includes the HTTP status code.
-        #       -O -  Writes the content to stdout.
-        # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
-        # the IPv6 ::1 address where there is no listening port.
-        # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
-        - CMD-SHELL
-        - >-
-          wget -qS -O - http://127.0.0.1:8082/ping 2>&1
-          | grep -q 'HTTP/1.1 200 OK'
-
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 15s
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 15s
 
 volumes:
-  traefik-acme-1:
-    driver: local
+    traefik-acme-1:
+        driver: local

--- a/services/weaviate/build/Dockerfile
+++ b/services/weaviate/build/Dockerfile
@@ -1,0 +1,21 @@
+FROM cr.weaviate.io/semitechnologies/weaviate:1.30.3
+
+ARG NONPRIV_USER=weaviate
+
+USER root
+
+# Install gosu. Weaviate is Alpine-based.
+RUN apk add --no-cache gosu || \
+    (apk add --no-cache curl gnupg && \
+    curl -L https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 -o /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true)
+
+COPY --from=config-dir /custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir /custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+
+RUN chmod +x /custom-docker-entrypoint.sh /custom-docker-entrypoint-nonpriv.sh
+
+ENTRYPOINT ["/custom-docker-entrypoint.sh"]
+# Original command from compose
+CMD ["--host", "0.0.0.0", "--port", "25080", "--scheme", "http"]

--- a/services/weaviate/build/build_images.sh
+++ b/services/weaviate/build/build_images.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+DOCKER="docker build"
+# Use buildx if available for better caching and progress
+if docker buildx version > /dev/null 2>&1; then
+    DOCKER="docker buildx build"
+fi
+
+IMAGE_TAG="localhost/localhost/weaviate:1.30.3-custom"
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
+
+echo "Building ${IMAGE_TAG}..."
+
+$DOCKER \
+    --file Dockerfile \
+    --build-context config-dir=../config \
+    --tag "${IMAGE_TAG}" \
+    --progress plain \
+    --load \
+    . 2>&1 \
+| tee $LOG_DIR/build-weaviate.log
+
+echo "Build complete: ${IMAGE_TAG}"

--- a/services/weaviate/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/weaviate/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+## set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# NOTE: Alpine's sh shell does not keep command-line history by default.
+
+# Set environment variables from mounted secrets files
+
+SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
+# The weaviate image is based on Alpine.
+# Hence we need to use a pure-shell alternative to our more frequent technique
+# of `export $( grep | xargs )`
+
+for FILE in "${SECRETS_MOUNT}"/*_secrets
+do
+    [ -f "$FILE" ] || continue
+    exec 3< "$FILE" # Open file descriptor 3. This robustly avoids subshell issues.
+    while IFS='=' read -r KEY VALUE <&3  # Read from file descriptor 3.
+    do
+        case "$KEY" in
+            # Skips comments and empty lines.
+            \#* | '') continue ;;
+            # Sets environment variables.
+            *) export "$KEY=$VALUE" ;;
+        esac
+    done
+    exec 3<&- # Close file descriptor 3.
+done
+
+# List one or more keys in plaintext separated by commas. Each key corresponds to a specific user identity below.
+export AUTHENTICATION_APIKEY_ALLOWED_KEYS="${WEAVIATE_USER_API_KEY}"
+
+# List one or more user identities, separated by commas. Each identity corresponds to a specific key above.
+export AUTHENTICATION_APIKEY_USERS="${WEAVIATE_USER_NAME}"
+
+
+# Process with original entrypoint, which can be discovered
+# from the host command-line with:
+#   docker image inspect cr.weaviate.io/semitechnologies/weaviate:1.30.3 | jq '.[0].Config.Entrypoint'
+exec "/bin/weaviate" "$@"

--- a/services/weaviate/config/custom-docker-entrypoint.sh
+++ b/services/weaviate/config/custom-docker-entrypoint.sh
@@ -1,39 +1,26 @@
 #!/usr/bin/env sh
-## set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
-# NOTE: Alpine's sh shell does not keep command-line history by default.
+set -e  # Exit immediately on error.
 
-# Set environment variables from mounted secrets files
-
-SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
-# The weaviate image is based on Alpine.
-# Hence we need to use a pure-shell alternative to our more frequent technique
-# of `export $( grep | xargs )`
-
-for FILE in "${SECRETS_MOUNT}"/*_secrets
+# Volume initialization logic (must run as root)
+echo "Initializing volumes..."
+for VOL in /var/lib/weaviate
 do
-    [ -f "$FILE" ] || continue
-    exec 3< "$FILE" # Open file descriptor 3. This robustly avoids subshell issues.
-    while IFS='=' read -r KEY VALUE <&3  # Read from file descriptor 3.
-    do
-        case "$KEY" in
-            # Skips comments and empty lines.
-            \#* | '') continue ;;
-            # Sets environment variables.
-            *) export "$KEY=$VALUE" ;;
-        esac
-    done
-    exec 3<&- # Close file descriptor 3.
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      chown -R 999:999 "$VOL"
+      chmod -R 777 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is already initialized."
+    fi
+  else
+    echo "Warning: Volume directory $VOL not found."
+  fi
 done
 
-# List one or more keys in plaintext separated by commas. Each key corresponds to a specific user identity below.
-export AUTHENTICATION_APIKEY_ALLOWED_KEYS="${WEAVIATE_USER_API_KEY}"
-
-# List one or more user identities, separated by commas. Each identity corresponds to a specific key above.
-export AUTHENTICATION_APIKEY_USERS="${WEAVIATE_USER_NAME}"
-
-
-# Process with original entrypoint, which can be discovered
-# from the host command-line with:
-#   docker image inspect cr.weaviate.io/semitechnologies/weaviate:1.30.3 | jq '.[0].Config.Entrypoint'
-exec "/bin/weaviate" "$@"
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to weaviate (UID 999)..."
+exec gosu 999:999 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/weaviate/deploy/compose.yml
+++ b/services/weaviate/deploy/compose.yml
@@ -1,91 +1,49 @@
 services:
-  init-weaviate-volumes:
-    restart: 'no'
+    weaviate:
+        restart: unless-stopped
+        image: localhost/localhost/weaviate:1.30.3-custom
+        profiles: [ weaviate, infrastructure-core, infrastructure, all ]
+        healthcheck:
+            test:
+                # The weaviate image is Alpine based and does not have curl installed.
+                # wget: -q    Turns off wget output, specifically the progress bar.
+                #       -S    Shows the server response, which includes the HTTP status code.
+                #       -O -  Writes the content to stdout.
+                # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
+                # the IPv6 ::1 address where there is no listening port.
+                # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
+                - CMD-SHELL
+                - >-
+                  wget -qS -O - http://127.0.0.1:25080/v1/.well-known/live 2>&1 | grep -q 'HTTP/1.1 200 OK'
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 5s
 
-    image: 'docker.io/debian:bookworm-slim'
-    profiles: [ init-volumes, weaviate, infrastructure-core, infrastructure, all ]
+        ports:
+            - 25080:25080
+            - 25051:25051
+        networks:
+            - agent-poc
+        volumes:
+            - weaviate-data-1:/var/lib/weaviate
+        secrets:
+            - weaviate_secrets
 
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - weaviate-data-1:/data-1
+        user: root
+        entrypoint: [ '/custom-docker-entrypoint.sh' ]
 
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
+        command: [ '--host', '0.0.0.0', '--port', '25080', '--scheme', 'http' ]
 
-        for VOL in 'data-1'
-        do
-          touch /$$VOL/.initialized
-          chown -R 999:999 /$$VOL
-          chmod -R 777 /$$VOL
-          ls -ld /$$VOL
-        done
-
-  weaviate:
-    restart: unless-stopped
-    depends_on:
-      init-weaviate-volumes:
-        condition: service_completed_successfully
-
-    image: cr.weaviate.io/semitechnologies/weaviate:1.30.3
-    profiles: [ weaviate, infrastructure-core, infrastructure, all ]
-    healthcheck:
-      # The weaviate image does not have curl installed. And since the image is based on
-      # busybox, curl is not available.
-      # wget: -q    Turns off wget output, specifically the progress bar.
-      #       -S    Shows the server response, which includes the HTTP status code.
-      #       -O -  Writes the content to stdout.
-      # Use the IPv4 loopback address. When 'localhost' is used, wget will try to use
-      # the IPv6 ::1 address where there is no listening port.
-      # grep: -q    Quiet. Exit code 0 if PATTERN is found, 1 otherwise
-      test:
-        - CMD-SHELL
-        - >-
-          wget -qS -O - http://127.0.0.1:25080/v1/.well-known/live 2>&1
-          | grep -q 'HTTP/1.1 200 OK'
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 5s
-
-    ports:
-    - 25080:25080
-    - 25051:25051
-    networks:
-      - agent-poc
-    volumes:
-      - weaviate-data-1:/var/lib/weaviate
-      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-    secrets:
-      - weaviate_secrets
-
-    #user: 'redis:redis'
-    entrypoint: [ '/custom-docker-entrypoint.sh']
-
-    command: [
-        '--host',
-        '0.0.0.0',
-        '--port',
-        '25080',
-        '--scheme',
-        'http'
-    ]
-
-    environment:
-      # Only environment variables that are important to the Docker environment
-      # will be configured here. All other environment variables are extracted
-      # to .env files for easier and more isolated management.
-      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
-      GRPC_PORT: 25051
-    env_file:
-      - weaviate.env
+        environment:
+            # Only environment variables that are important to the Docker environment
+            # will be configured here. All other environment variables are extracted
+            # to .env files for easier and more isolated management.
+            PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+            GRPC_PORT: 25051
+        env_file:
+            - weaviate.env
 
 volumes:
-  weaviate-data-1:
-    driver: local
+    weaviate-data-1:
+        driver: local

--- a/services/webui-server/build/Dockerfile
+++ b/services/webui-server/build/Dockerfile
@@ -12,8 +12,10 @@ RUN \
     curl \
     gnupg \
     wget \
+    gosu \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* ; \
+    gosu nobody true ; \
     #
     # Create a custom group with GROUP_ID
     # Then create a custom user with USER_ID and GROUP_ID
@@ -42,18 +44,19 @@ RUN \
 # Copy in Dockerfile has a slightly different syntax. When copying a file to
 # a directory, the destination must end with a trailing slash.
 # See: https://docs.docker.com/reference/dockerfile/#destination-1
-COPY --from=config-dir ./custom-docker-entrypoint.sh /
-COPY --from=config-dir ./run_webui_server.sh /
+COPY --from=config-dir ./custom-docker-entrypoint.sh /custom-docker-entrypoint.sh
+COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entrypoint-nonpriv.sh
+COPY --from=config-dir ./run_webui_server.sh /run_webui_server.sh
 
 COPY --from=dependency-gate-dir ./wait_for_resource.sh /
 
 
 
-## RUN chmod a+x /custom-docker-entrypoint.sh \
-##     && chmod a+x /run_webui_server.sh \
-##     && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
-##     && chown ${USER_ID}:${GROUP_ID} /run_webui_server.sh
-RUN chmod a+x /run_webui_server.sh \
+RUN chmod a+x /custom-docker-entrypoint.sh \
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
+    && chmod a+x /run_webui_server.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh \
     && chown ${USER_ID}:${GROUP_ID} /run_webui_server.sh
 
 # Set the working directory inside the container
@@ -93,7 +96,6 @@ USER root
 # The user will run the following command:
 #   sudo mount /app/frontend
 RUN apt-get update \
-    && apt-get install -y sudo \
     #
     # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
     # This module has a broken "Spare Read" features that failes on Docker / overlay2.
@@ -102,12 +104,6 @@ RUN apt-get update \
     && echo "nfs:/frontend /mnt/frontend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
     && echo "/mnt/frontend-nfs /app/frontend none defaults,bind,noauto 0 0" >> /etc/fstab \
     && echo "/home/node/node_modules-storage /app/frontend/node_modules none defaults,bind,noauto 0 0" >> /etc/fstab \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/mount /mnt/frontend-nfs' >> /etc/sudoers \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/umount /mnt/frontend-nfs' >> /etc/sudoers \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/mount /app/frontend' >> /etc/sudoers \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/umount /app/frontend' >> /etc/sudoers \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/mount /app/frontend/node_modules' >> /etc/sudoers \
-    && echo 'node ALL=(ALL) NOPASSWD: /usr/bin/umount /app/frontend/node_modules' >> /etc/sudoers \
     && mkdir -p /mnt/frontend-nfs \
     && mkdir -p /home/node/node_modules-storage \
     && chown ${USER_ID}:${GROUP_ID} /home/node/node_modules-storage \

--- a/services/webui-server/build/build_images.sh
+++ b/services/webui-server/build/build_images.sh
@@ -2,7 +2,9 @@
 
 ## set -e: Exit immediately if a command exits with a non-zero status.
 ## set -u: Treat unset variables as an error and exit immediately.
-set -eu
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
 
 #
@@ -17,6 +19,9 @@ set -eu
 DOCKER="docker buildx"
 # DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
+LOG_DIR=../../../logs
+
+mkdir -p $LOG_DIR
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
@@ -26,7 +31,9 @@ $DOCKER build \
   --build-context frontend-dir=../../../frontend/ \
   --target production \
   --tag localhost/localhost/answers-frontend:node-22-bookworm \
-  .
+  --progress plain \
+  . 2>&1 \
+| tee $LOG_DIR/build-frontend.log
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
@@ -36,4 +43,6 @@ $DOCKER build \
   --build-context frontend-dir=../../../frontend/ \
   --target dev \
   --tag localhost/localhost/answers-frontend-dev:node-22-bookworm \
-  .
+  --progress plain \
+  . 2>&1 \
+| tee $LOG_DIR/build-frontend-dev.log

--- a/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# Set environment variables from mounted secrets files
+
+SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
+# shellcheck disable=SC2046
+export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
+
+# Transition to the non-privileged entrypoint
+
+cd /app/frontend
+
+
+exec "$@"

--- a/services/webui-server/config/custom-docker-entrypoint.sh
+++ b/services/webui-server/config/custom-docker-entrypoint.sh
@@ -27,14 +27,19 @@ FRONTEND_VOLS="/app/frontend/node_modules"
 for VOL in $FRONTEND_VOLS
 do
   if [ -d "$VOL" ]; then
-    if [ ! -f "$VOL/.initialized" ]; then
-      echo "Initializing $VOL..."
-      touch "$VOL/.initialized"
-      chown -R 1000:1000 "$VOL"
-      chmod -R 755 "$VOL"
-      ls -ld "$VOL"
+    # Only initialize if it's a mount point (volume)
+    if grep -q " $VOL " /proc/self/mounts; then
+      if [ ! -f "$VOL/.initialized" ]; then
+        echo "Initializing $VOL..."
+        touch "$VOL/.initialized"
+        chown -R 1000:1000 "$VOL"
+        chmod -R 755 "$VOL"
+        ls -ld "$VOL"
+      else
+        echo "$VOL is already initialized."
+      fi
     else
-      echo "$VOL is already initialized."
+      echo "$VOL is part of the image, skipping initialization."
     fi
   fi
 done

--- a/services/webui-server/config/custom-docker-entrypoint.sh
+++ b/services/webui-server/config/custom-docker-entrypoint.sh
@@ -4,31 +4,41 @@ set -e  # Exit immediately on error.
 set -u  # Unbound variables are errors.
 set -o pipefail  # Use right-most non-zero exit code from a pipe.
 
-# Set environment variables from mounted secrets files
-
-SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
-# shellcheck disable=SC2046
-export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
-
+# NFS mounting logic (if requested)
 if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
-    # If running with NFS, we need to mask node_modules with a tmpfs so it's container-local
     echo "Running in NFS mode. Mounting file systems..."
-    # The command must exactly match what is permitted in the /etc/sudoers file to avoid execution denial.
-    sudo /usr/bin/mount /mnt/frontend-nfs
-    sudo /usr/bin/mount /app/frontend
+    mount /mnt/frontend-nfs || echo "Warning: Failed to mount /mnt/frontend-nfs"
+    mount /app/frontend || echo "Warning: Failed to mount /app/frontend"
 
     # Ensure directory exists before mounting
     mkdir -p /app/frontend/node_modules
-    # Check if already mounted (to avoid double mounting if container restarts but didn't fully die?) 
-    # Actually, simpler to just try mount.
-    sudo /usr/bin/mount /app/frontend/node_modules
+    mount /app/frontend/node_modules || echo "Warning: Failed to mount /app/frontend/node_modules"
 
-    # Wait two seconds for the NFS server to start. This delay accounts for the periodic Unison
-    # sync loop (Host -> /staging -> /exports) required to decouple the NFS export from the bind-mount.
+    # Wait for the NFS server/sync loop
     sleep 2
 fi
 
-cd /app/frontend
+# Volume initialization logic (must run as root)
+echo "Initializing frontend volumes..."
 
+# Identify potential volume mount points in the frontend container
+FRONTEND_VOLS="/app/frontend/node_modules"
 
-exec "$@"
+for VOL in $FRONTEND_VOLS
+do
+  if [ -d "$VOL" ]; then
+    if [ ! -f "$VOL/.initialized" ]; then
+      echo "Initializing $VOL..."
+      touch "$VOL/.initialized"
+      chown -R 1000:1000 "$VOL"
+      chmod -R 755 "$VOL"
+      ls -ld "$VOL"
+    else
+      echo "$VOL is already initialized."
+    fi
+  fi
+done
+
+# Transition to the non-privileged entrypoint
+echo "Dropping privileges to node (UID 1000)..."
+exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/webui-server/deploy/compose-autotest.yml
+++ b/services/webui-server/deploy/compose-autotest.yml
@@ -66,8 +66,9 @@ services:
       ##SRC - frontend-autotest-home-1:/home/node
       ##SRC - frontend-autotest-node-modules-1:/app/frontend/node_modules
 
+    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
     command: [ '/run_webui_server.sh' ]
-    user: '1000:1000'
+    user: root
 
 
 volumes:

--- a/services/webui-server/deploy/compose.yml
+++ b/services/webui-server/deploy/compose.yml
@@ -1,76 +1,34 @@
-
 services:
-  init-frontend-volumes:
-    restart: 'no'
+    webui-server:
+        image: 'localhost/localhost/answers-frontend:node-22-bookworm'
+        profiles: [ frontend, all ]
 
-    image: 'docker.io/node:22-bookworm-slim'
-    profiles: [ init-volumes, frontend, all ]
+        environment:
+            # Only environment variables that are important to the Docker environment
+            # will be configured here. All other environment variables are extracted
+            # to .env files for easier and more isolated management.
+            CHOKIDAR_USEPOLLING: 'true'
+        #   - NODE_ENV=production
+        ## Do not expose 5173 ... To prevent XSS (cross site scripting) usage, we want all
+        ## traffic to go thru the reserve-proxy server at 15173.
+        # ports:
+        #   - '5173:5173'
+        networks:
+            - agent-poc
+        volumes: []
+            # Mount the project directory to /app in the container
+            ##SRC - ../../../frontend/app:/app:ro
+            ## - ../../dependency-gate/wait_for_resource.sh:/wait_for_resource.sh
+            # Mount important script into the container when we are
+            # avoiding rebuilding images to capture their latest version.
+            ##SRC - ../build/run_webui_server.sh:/run_webui_server.sh:ro
+            # Mounting a local area to use container-installed dependencies
+            ##SRC - frontend-home-1:/home/node
 
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - frontend-home-1:/home/node/home-1
-      - frontend-node-modules-1:/home/node/node-modules-1
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/node/
-
-        for VOL in 'home-1' 'node-modules-1'
-        do
-          touch /home/node/$$VOL/.initialized
-          chown -R 1000:1000 /home/node/$$VOL
-          chmod -R 755 /home/node/$$VOL
-          ls -ld /home/node/$$VOL
-        done
-
-
-
-  webui-server:
-    depends_on:
-      init-frontend-volumes:
-        condition: service_completed_successfully
-
-    image: 'localhost/localhost/answers-frontend:node-22-bookworm'
-    profiles: [ frontend, all ]
-
-    environment:
-      # Only environment variables that are important to the Docker environment
-      # will be configured here. All other environment variables are extracted
-      # to .env files for easier and more isolated management.
-      CHOKIDAR_USEPOLLING: 'true'
-    #   - NODE_ENV=production
-    ## Do not expose 5173 ... To prevent XSS (cross site scripting) usage, we want all
-    ## traffic to go thru the reserve-proxy server at 15173.
-    # ports:
-    #   - '5173:5173'
-    networks:
-      - agent-poc
-    volumes: []
-      # Mount the project directory to /app in the container
-      ##SRC - ../../../frontend/app:/app:ro
-      ## - ../../dependency-gate/wait_for_resource.sh:/wait_for_resource.sh
-      # Mount important script into the container when we are
-      # avoiding rebuilding images to capture their latest version.
-      ##SRC - ../build/run_webui_server.sh:/run_webui_server.sh:ro
-      # Mounting a local area to use container-installed dependencies
-      ##SRC - frontend-home-1:/home/node
-      ##SRC - frontend-node-modules-1:/app/frontend/node_modules
-
-    command: [ '/run_webui_server.sh' ]
-    user: '1000:1000'
+        user: root
+        entrypoint: [ '/custom-docker-entrypoint.sh' ]
+        command: [ '/run_webui_server.sh' ]
 
 volumes:
-  frontend-home-1:
-    driver: local
-  frontend-node-modules-1:
-    driver: local
-  frontend-init-signal-1:
-    driver: local
+    frontend-home-1:
+        driver: local


### PR DESCRIPTION
This PR reduces the number of containers, images, and services by merging the run-and-exit volume initialization into the main compose services.

The reason for running the volume initialization in a separate service was to isolate privileged root-level operations (ex: `chown`) from non-privileged steady-state running. However, this has lead to a lot of clutter from exited containers, operational complexity from fragile dependencies, and other unnecessary problems.

Now, each service's container starts as a short-lived phase as a privileged root-user process then replaces itself with a non-privileged non-root process. During the privileged phase, the container can initialize new volumes (including changing the directory ownership) and mount file systems (which is another privileged operation).