### PR TITLE
fix env start instabilities

### DIFF
--- a/services/api-server/build/Dockerfile
+++ b/services/api-server/build/Dockerfile
@@ -49,7 +49,6 @@ RUN \
     #
     apt-get update \
     && apt-get install -y --no-install-recommends \
-    nfs-common \
     libgl1 \
     libgl1-mesa-dri \
     libglu1-mesa \
@@ -179,11 +178,14 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
     fuse3 \
+    fuse \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     # Install weed CLI
-    && curl -L https://github.com/seaweedfs/seaweedfs/releases/download/3.64/linux_amd64.tar.gz | tar xz -C /usr/local/bin weed
+    && curl -L https://github.com/seaweedfs/seaweedfs/releases/download/3.64/linux_amd64.tar.gz | tar xz -C /usr/local/bin weed \
+    && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
+    && usermod -aG fuse python
 
 RUN \
     set -eux ; \

--- a/services/api-server/build/cuda12.Dockerfile
+++ b/services/api-server/build/cuda12.Dockerfile
@@ -140,7 +140,6 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
     curl \
-    nfs-common \
     libgl1 \
     libgl1-mesa-dri \
     libglu1-mesa \
@@ -257,21 +256,11 @@ ARG GROUP_ID=1000
 
 USER root
 
-# This is to allow the container user to mount the directory from the NFS server.
-# The user will run the following command:
-#   sudo mount /app/backend
 RUN apt-get update \
-    && mkdir -p /mnt/backend-nfs \
-    #
-    # FSAL_VFS is the only Ganesha module for exporting standard Linux filesystem.
-    # This module has a broken "Spare Read" features that failes on Docker / overlay2.
-    # The NFS client is forced into 4.1 protocol which does not support the failing READ_PLUS.
-    #
-    && echo "nfs:/backend /mnt/backend-nfs nfs defaults,noauto,noac,nfsvers=4.1 0 0" >> /etc/fstab \
-    && echo "/mnt/backend-nfs /app/backend none defaults,bind,noauto 0 0" >> /etc/fstab \
-    && echo "/home/python/.venv-storage /app/backend/.venv none defaults,bind,noauto 0 0" >> /etc/fstab \
     && mkdir -p /home/python/.venv-storage && chown ${USER_ID}:${GROUP_ID} /home/python/.venv-storage \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # Install weed CLI
+    && curl -L https://github.com/seaweedfs/seaweedfs/releases/download/3.64/linux_amd64.tar.gz | tar xz -C /usr/local/bin weed
 
 RUN \
     set -eux ; \

--- a/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -5,7 +5,21 @@ set -eu
 
 cd /app/backend
 
-if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
+if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
+
+    # Wait for mount
+    attempt=0
+    while ! mountpoint -q /app/backend; do
+        sleep 1
+        attempt=$((attempt+1))
+        if [ $attempt -ge 30 ]; then
+            echo "Error: Mount failed to appear after 30 seconds."
+            exit 1
+        fi
+    done
+
+    echo "Mount active."
+
     #    
     # Create the virtual environment only once.
     #
@@ -21,7 +35,6 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
     # Use --frozen to prevent writing to the lockfile (which might be read-only or owned by another user)
     SYNC_CMD="uv sync --frozen --dev --all-packages"
 
-    SYNC_CMD="uv sync --frozen --dev --all-packages"
     EXTRA_ARGS=""
 
     if [ "$GPU_MODE" == "cuda12" ]; then
@@ -46,8 +59,6 @@ if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
         exit $EXIT_CODE
     fi
 fi
-
-ls -la .
 
 source .venv/bin/activate
 

--- a/services/api-server/config/custom-docker-entrypoint.sh
+++ b/services/api-server/config/custom-docker-entrypoint.sh
@@ -40,6 +40,7 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     
     # Ensure mount point exists
     mkdir -p /app/backend
+    chown 1000:1000 /app/backend
     
     # Run supervisor
     # We rely on /etc/supervisord.conf
@@ -50,7 +51,7 @@ else
     
     # Identify potential volume mount points in the backend containers
     # API Server volumes
-    API_VOLS="/app/backend/.venv /staging"
+    API_VOLS="/staging"
     
     for VOL in $API_VOLS
     do

--- a/services/api-server/config/supervisord.conf
+++ b/services/api-server/config/supervisord.conf
@@ -11,7 +11,8 @@ pidfile=/var/run/supervisord.pid
 ; For flexibility, we can use a wrapper or define the standard command.
 ; However, we need environment variables (ACCESS_KEY etc). 
 ; Supervisor inherits env vars from the shell that started it.
-command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/backend" -dir="/app/backend" -dirAutoCreate=true -umask=000 -cacheCapacityMB=1000 -dirCacheTTL=15s %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/backend" -dir="/app/backend" -dirAutoCreate=true -umask=000 -map.uid=1000:0 -map.gid=1000:0 -cacheCapacityMB=1000 %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+user=root
 autostart=true
 autorestart=true
 startretries=3
@@ -41,6 +42,8 @@ stdout_logfile_maxbytes=0
 ; The original command to run the server, wrapped in the non-priv entrypoint to handle venv setup
 command=/custom-docker-entrypoint-nonpriv.sh /run_api_server.sh
 user=python
+# Explicitly set HOME.
+environment=HOME="/home/python"
 autostart=true
 autorestart=true
 ; This ensures app doesn't start until mount-helper finishes (conceptually).

--- a/services/api-server/deploy/automated-test.env
+++ b/services/api-server/deploy/automated-test.env
@@ -31,7 +31,7 @@ S3_ENDPOINT_URL=http://seaweedfs:9000
 S3_BUCKET_NAME=documents-autotest
 S3_ACCESS_KEY=agentic-autotest
 
-SEAWEEDFS_FILER=http://seaweedfs:9002
+SEAWEEDFS_FILER=seaweedfs:9002
 
 # See https://langfuse.com/docs/sdk/python/low-level-sdk
 #

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -1,47 +1,4 @@
 services:
-  init-backend-autotest-volumes:
-    restart: 'no'
-
-    image: 'docker.io/python:3.12.8-slim-bookworm'
-    profiles: [ init-volumes, backend-autotest, all ]
-
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - backend-autotest-home-1:/home/python/test-home-1
-      - backend-autotest-venv-1:/home/python/test-venv-1
-      - backend-autotest-staging-1:/home/python/test-staging-1
-      - backend-autotest-home-2:/home/python/test-home-2
-      - backend-autotest-venv-2:/home/python/test-venv-2
-      - backend-autotest-staging-2:/home/python/test-staging-2
-      - backend-autotest-home-3:/home/python/test-home-3
-      - backend-autotest-venv-3:/home/python/test-venv-3
-      - backend-autotest-home-4:/home/python/test-home-4
-      - backend-autotest-venv-4:/home/python/test-venv-4
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/python/
-
-        for VOL in \
-          'test-home-1' 'test-venv-1' 'test-staging-1' \
-          'test-home-2' 'test-venv-2' 'test-staging-2' \
-          'test-venv-3' 'test-home-3' \
-          'test-venv-4' 'test-home-4'
-        do
-          touch /home/python/$$VOL/.initialized
-          chown -R 1000:1000 /home/python/$$VOL
-          chmod -R 755 /home/python/$$VOL
-          ls -ld /home/python/$$VOL
-        done
-
   backend-autotest-dependency-gate:
     restart: 'no'
 
@@ -73,10 +30,6 @@ services:
 
 
   api-server-autotest:
-    depends_on:
-      init-backend-autotest-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cuda12'
     profiles: [ backend-autotest, all ]
     privileged: true
@@ -116,7 +69,9 @@ services:
       - ../config/run_api_server.sh:/run_api_server.sh:ro
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
-      ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/supervisord.conf:/etc/supervisord.conf:ro
+      - ../config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
       ##SRC - backend-autotest-home-1:/home/python
       ##SRC - backend-autotest-venv-1:/app/backend/.venv
       - backend-autotest-staging-1:/staging
@@ -163,10 +118,6 @@ services:
 
 
   automated-pytest:
-    depends_on:
-      init-backend-autotest-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cpu'
     profiles: [ backend-autotest, automated-pytest, all ]
     privileged: true
@@ -209,7 +160,9 @@ services:
       # avoiding rebuilding images to capture their latest version.
       - ../config/run_automated_test.sh:/run_automated_test.sh:ro
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
-      ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/supervisord.conf:/etc/supervisord.conf:ro
+      - ../config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
       ##SRC - backend-autotest-home-4:/home/python
       ##SRC - backend-autotest-venv-4:/app/backend/.venv
     secrets:
@@ -259,3 +212,8 @@ volumes:
     driver: local
   backend-autotest-venv-4:
     driver: local
+
+networks:
+  agent-poc:
+    name: agent_agent-poc
+    external: true

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -133,9 +133,5 @@ services:
 volumes:
   backend-init-signal-1:
     driver: local
-  backend-home-1:
-    driver: local
-  backend-venv-1:
-    driver: local
   backend-staging-1:
     driver: local

--- a/services/celery-worker/config/celery-docker-entrypoint.sh
+++ b/services/celery-worker/config/celery-docker-entrypoint.sh
@@ -5,26 +5,27 @@ set -eu
 if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     echo "Running in FUSE mode with Supervisor..."
     mkdir -p /app/backend
+    chown 1000:1000 /app/backend
     
     # Run Supervisor with the pre-baked configuration
-    exec /usr/bin/supervisord -c /etc/celery-supervisord.conf
+    exec /usr/bin/supervisord -c /etc/supervisord.conf
 else
     # Standard Mode (reuse existing logic if possible, or replicate it)
     # Since we can't easily reuse logic without calling scripts, allow me to replicate the standard non-FUSE flow.
     
     cd /app/backend
 
-    if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
-    #    
-    # Create the virtual environment only once.
-    #
-    # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
-    # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
-    if [ ! -f ".venv/CACHEDIR.TAG" ] \
-        || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
-    then
-        uv venv --allow-existing
-    fi
+    if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
+        #    
+        # Create the virtual environment only once.
+        #
+        # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
+        # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
+        if [ ! -f ".venv/CACHEDIR.TAG" ] \
+            || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
+        then
+            uv venv --allow-existing
+        fi
         
         SYNC_CMD="uv sync --frozen --dev --all-packages"
         if [ "$GPU_MODE" == "cuda12" ]; then

--- a/services/celery-worker/config/celery-flower-supervisord.conf
+++ b/services/celery-worker/config/celery-flower-supervisord.conf
@@ -7,7 +7,8 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:weed-mount]
-command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/frontend" -dir="/app/frontend" -dirAutoCreate=true -umask=000 -map.uid=1000:0 -map.gid=1000:0 -cacheCapacityMB=1000 %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/backend" -dir="/app/backend" -dirAutoCreate=true -umask=000 -map.uid=1000:0 -map.gid=1000:0 -cacheCapacityMB=1000 %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+user=root
 autostart=true
 autorestart=true
 startretries=3
@@ -17,7 +18,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:mount-helper]
-command=/usr/local/bin/webui_mount_helper.sh
+command=/usr/local/bin/celery_mount_helper.sh
 autostart=true
 autorestart=false
 startsecs=0
@@ -29,9 +30,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:app]
-command=/custom-docker-entrypoint-nonpriv.sh /run_webui_server.sh
-user=node
-environment=HOME="/home/node",USER="node"
+command=/custom-docker-entrypoint-nonpriv.sh /run_celery_flower.sh
+user=python
+# Explicitly set HOME.
+environment=HOME="/home/python"
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr

--- a/services/celery-worker/config/celery-supervisord.conf
+++ b/services/celery-worker/config/celery-supervisord.conf
@@ -7,7 +7,8 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:weed-mount]
-command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/backend" -dir="/app/backend" -dirAutoCreate=true -umask=000 -cacheCapacityMB=1000 -dirCacheTTL=15s %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+command=weed mount -filer="%(ENV_SEAWEEDFS_FILER)s" -filer.path="/buckets/codebase/backend" -dir="/app/backend" -dirAutoCreate=true -umask=000 -map.uid=1000:0 -map.gid=1000:0 -cacheCapacityMB=1000 %(ENV_WEED_MOUNT_EXTRA_ARGS)s
+user=root
 autostart=true
 autorestart=true
 startretries=3
@@ -31,6 +32,8 @@ stdout_logfile_maxbytes=0
 [program:app]
 command=/custom-docker-entrypoint-nonpriv.sh /run_celery_worker.sh
 user=python
+# Explicitly set HOME.
+environment=HOME="/home/python"
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr

--- a/services/celery-worker/config/celery_mount_helper.sh
+++ b/services/celery-worker/config/celery_mount_helper.sh
@@ -22,11 +22,7 @@ echo "$ECHO_PREFIX Mount active."
 # Or fall back to /home/python/.venv-storage checks if needed (but celery compose maps volumes differently?)
 # The previous script checked /app/.venv
 
-if [ -d "/app/.venv" ] && ! mountpoint -q /app/backend/.venv; then
-    echo "$ECHO_PREFIX Overlaying .venv from /app/.venv..."
-    mkdir -p /app/backend/.venv
-    mount --bind /app/.venv /app/backend/.venv || echo "$ECHO_PREFIX Warning: Failed to mount .venv"
-elif [ -d "/home/python/.venv-storage" ] && ! mountpoint -q /app/backend/.venv; then
+if [ -d "/home/python/.venv-storage" ] && ! mountpoint -q /app/backend/.venv; then
     echo "$ECHO_PREFIX Overlaying .venv from /home/python/.venv-storage..."
     mkdir -p /app/backend/.venv
     mount --bind /home/python/.venv-storage /app/backend/.venv || echo "$ECHO_PREFIX Warning: Failed to mount .venv"

--- a/services/celery-worker/config/custom-docker-entrypoint.sh
+++ b/services/celery-worker/config/custom-docker-entrypoint.sh
@@ -13,7 +13,7 @@ set -eu
 
 cd /app/backend
 
-if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
+if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     #    
     # Create the virtual environment only once.
     #

--- a/services/celery-worker/deploy/automated-test.env
+++ b/services/celery-worker/deploy/automated-test.env
@@ -32,7 +32,7 @@ S3_ENDPOINT_URL=http://seaweedfs:9000
 S3_BUCKET_NAME=documents-autotest
 S3_ACCESS_KEY=agentic-autotest
 
-SEAWEEDFS_FILER=http://seaweedfs:9002
+SEAWEEDFS_FILER=seaweedfs:9002
 
 # See https://langfuse.com/docs/sdk/python/low-level-sdk
 #

--- a/services/celery-worker/deploy/common-autotest.compose.yml
+++ b/services/celery-worker/deploy/common-autotest.compose.yml
@@ -2,10 +2,6 @@ services:
 
 
   celery-worker-autotest:
-    depends_on:
-      init-backend-autotest-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cuda12'
     profiles: [ backend-autotest, all ]
     privileged: true
@@ -45,6 +41,9 @@ services:
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/celery-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/celery-supervisord.conf:/etc/supervisord.conf:ro
+      - ../../api-server/config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
       ##SRC - backend-autotest-home-2:/home/python
       ##SRC - backend-autotest-venv-2:/app/.venv
       - backend-autotest-staging-2:/staging
@@ -89,10 +88,6 @@ services:
       start_period: 5s
 
   celery-flower-autotest:
-    depends_on:
-      init-backend-autotest-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-backend-dev:python-3.12-cpu'
     profiles: [ backend-autotest, all ]
     privileged: true
@@ -128,6 +123,9 @@ services:
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ../build/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/celery-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/celery-flower-supervisord.conf:/etc/supervisord.conf:ro
+      - ../../api-server/config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
       ##SRC - backend-autotest-home-3:/home/python
       ##SRC - backend-autotest-venv-3:/app/.venv
     secrets:
@@ -161,3 +159,8 @@ services:
       timeout: 15s
       retries: 5
       start_period: 5s
+
+networks:
+  agent-poc:
+    name: agent_agent-poc
+    external: true

--- a/services/dev-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/dev-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -18,7 +18,7 @@ if [ -d "/app/backend" ]; then
     (
         cd /app/backend
 
-        if [ "${USE_NFS_SRC_DIR:-false}" = "true" ]; then
+        if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
             #    
             # Create the virtual environment only once.
             #

--- a/services/dev-server/config/supervisord.conf
+++ b/services/dev-server/config/supervisord.conf
@@ -33,6 +33,7 @@ stdout_logfile_maxbytes=0
 # Using sleep infinity to keep container alive for interactive use
 command=/custom-docker-entrypoint-nonpriv.sh sleep infinity
 user=python
+environment=HOME="/home/python"
 autostart=true
 autorestart=true
 stderr_logfile=/dev/stderr

--- a/services/webui-server/build/Dockerfile
+++ b/services/webui-server/build/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js image as the base image
-FROM docker.io/node:22-bookworm-slim AS production
+FROM docker.io/node:22-bookworm-slim AS production-base
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -23,19 +23,7 @@ RUN \
     #
     set -eux ; \
     ( id -g ${GROUP_ID} > /dev/null 2>&1 ) || groupadd -g ${GROUP_ID} node ; \
-    ( id -u ${USER_ID} > /dev/null 2>&1 ) || useradd -m -u ${USER_ID} -g ${GROUP_ID} node ;
-
-RUN \
-    set -eux ; \
-    export DEBIAN_FRONTEND=noninteractive ; \
-    #
-    # Locally required Debian packages
-    #
-    apt-get update \
-    && apt-get install -y --no-install-recommends \
-    nfs-common \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    ( id -u ${USER_ID} > /dev/null 2>&1 ) || useradd -m -u ${USER_ID} -g ${GROUP_ID} node
 
 # Copy the build-and-run script.
 #
@@ -76,20 +64,32 @@ COPY --from=frontend-dir ./src/ /app/frontend/src/
 
 RUN chown -R ${USER_ID}:${GROUP_ID} /app/frontend/
 
-# Switch to the custom user
-USER ${USER_ID}:${GROUP_ID}
-
-RUN \
-    set -eux ; \
-    npm install --ignore-scripts
-
 ENTRYPOINT [ "bash", "/custom-docker-entrypoint.sh" ]
 
 # Build the app then start the Vue.js development server
 CMD ["run_webui_server.sh"]
 
+# Switch to the custom user
+USER ${USER_ID}:${GROUP_ID}
 
-FROM production AS dev
+FROM production-base AS production
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# Switch to the custom user
+USER ${USER_ID}:${GROUP_ID}
+
+
+RUN \
+    set -eux ; \
+    npm install --ignore-scripts
+
+# Switch to the custom user
+USER ${USER_ID}:${GROUP_ID}
+
+
+FROM production-base AS dev
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -120,6 +120,12 @@ RUN \
     patch \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+
+ENTRYPOINT [ "bash", "/custom-docker-entrypoint.sh" ]
+
+# Build the app then start the Vue.js development server
+CMD ["run_webui_server.sh"]
 
 # Switch to the custom user
 USER ${USER_ID}:${GROUP_ID}

--- a/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -10,6 +10,26 @@ SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
 # shellcheck disable=SC2046
 export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
 
+
+# Only run if FUSE is enabled
+if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
+
+    echo "Waiting for mount at /app/frontend..."
+
+    # Wait for mount
+    attempt=0
+    while ! mountpoint -q /app/frontend; do
+        sleep 1
+        attempt=$((attempt+1))
+        if [ $attempt -ge 30 ]; then
+            echo "Error: Mount failed to appear after 30 seconds."
+            exit 1
+        fi
+    done
+
+    echo "Mount active."
+fi
+
 # Transition to the non-privileged entrypoint
 
 cd /app/frontend

--- a/services/webui-server/config/custom-docker-entrypoint.sh
+++ b/services/webui-server/config/custom-docker-entrypoint.sh
@@ -21,27 +21,6 @@ else
     # Identify potential volume mount points in the frontend container
     FRONTEND_VOLS="/app/frontend/node_modules"
     
-    for VOL in $FRONTEND_VOLS
-    do
-      if [ -d "$VOL" ]; then
-        # Only initialize if it's a mount point (volume)
-        if grep -q " $VOL " /proc/self/mounts; then
-          if [ ! -f "$VOL/.initialized" ]; then
-            echo "Initializing $VOL..."
-            touch "$VOL/.initialized"
-            chown -R 1000:1000 "$VOL"
-            chmod -R 755 "$VOL"
-            ls -ld "$VOL"
-          else
-            echo "$VOL is already initialized."
-          fi
-        else
-          # echo "$VOL is part of the image, skipping initialization."
-          :
-        fi
-      fi
-    done
-    
     # Transition to the non-privileged entrypoint
     echo "Dropping privileges to node (UID 1000)..."
     exec gosu 1000:1000 /custom-docker-entrypoint-nonpriv.sh "$@"

--- a/services/webui-server/config/run_webui_server.sh
+++ b/services/webui-server/config/run_webui_server.sh
@@ -12,15 +12,28 @@ export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
 
 
 # Install dependencies
-# Use npm ci to ensure we strictly follow package-lock.json and do not attempt to write to it.
-# This prevents permission errors if package-lock.json is read-only or owned by another user.
+# Determine install command based on whether node_modules is a mount point
+# npm ci tries to remove the node_modules directory which fails on mount points.
+NPM_CMD="npm ci"
+if grep -q " /app/frontend/node_modules " /proc/mounts; then
+    echo "node_modules is a bind mount. Using npm install."
+    NPM_CMD="npm install"
+fi
+
 set +e
-npm ci
+$NPM_CMD
 EXIT_CODE=$?
 set -e
 
 if [ $EXIT_CODE -ne 0 ]; then
-    echo "Error: npm ci failed."
+    echo "Error: $NPM_CMD failed. Attempting to recover by cleaning cache..."
+    npm cache clean --force
+    $NPM_CMD
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Error: npm ci failed again after cache clean."
     echo "This is likely because package-lock.json is not up-to-date with package.json."
     echo "Please run 'npm install' on your host machine to update package-lock.json."
     exit $EXIT_CODE

--- a/services/webui-server/config/webui_mount_helper.sh
+++ b/services/webui-server/config/webui_mount_helper.sh
@@ -23,16 +23,18 @@ done
 echo "$ECHO_PREFIX Mount active."
 
 # Overlay node_modules
-# Logic from original entrypoint: checks /home/node/node_modules-storage or /home/node/node-modules-1
-if [ -d "/home/node/node_modules-storage" ]; then
-     echo "$ECHO_PREFIX Overlaying node_modules from /home/node/node_modules-storage..."
-     mkdir -p /app/frontend/node_modules
-     mount --bind /home/node/node_modules-storage /app/frontend/node_modules || echo "$ECHO_PREFIX Warn: Bind mount failed"
-elif [ -d "/home/node/node-modules-1" ]; then
-     echo "$ECHO_PREFIX Overlaying node_modules from /home/node/node-modules-1..."
-     mkdir -p /app/frontend/node_modules
-     mount --bind /home/node/node-modules-1 /app/frontend/node_modules || echo "$ECHO_PREFIX Warn: Bind mount failed"
+# Create and mount local node_modules to avoid sharing the ephemral node_modules
+# directory across multiple containers.
+LOCAL_MODULES="/home/node/node_modules-storage"
+if [ ! -d "$LOCAL_MODULES" ]; then
+    echo "$ECHO_PREFIX Creating local storage at $LOCAL_MODULES..."
+    mkdir -p "$LOCAL_MODULES"
+    chown 1000:1000 "$LOCAL_MODULES"
 fi
+
+echo "$ECHO_PREFIX Overlaying node_modules from $LOCAL_MODULES..."
+mkdir -p /app/frontend/node_modules
+mount --bind "$LOCAL_MODULES" /app/frontend/node_modules || echo "$ECHO_PREFIX Warn: Bind mount failed"
 
 echo "$ECHO_PREFIX Done."
 exit 0

--- a/services/webui-server/deploy/compose-autotest.yml
+++ b/services/webui-server/deploy/compose-autotest.yml
@@ -1,43 +1,6 @@
 
 services:
-  init-frontend-autotest-volumes:
-    restart: 'no'
-
-    image: 'docker.io/node:22-bookworm-slim'
-    profiles: [ init-volumes, frontend-autotest, all ]
-
-    # No network is needed to initialize named volumes
-    network_mode: none
-    volumes:
-      - frontend-autotest-home-1:/home/node/home-1
-      - frontend-autotest-node-modules-1:/home/node/node-modules-1
-
-    entrypoint: 'bash'
-    command:
-      - '-c'
-      # Beware that docker-compose also performs variable interpolation.
-      # So we need to escape the dollar sign with $$name so that bash
-      # will recieve our embedded script with $name. 
-      - |
-        set -ex ;
-
-        ls -ld /home/node/
-
-        for VOL in 'home-1' 'node-modules-1'
-        do
-          touch /home/node/$$VOL/.initialized
-          chown -R 1000:1000 /home/node/$$VOL
-          chmod -R 755 /home/node/$$VOL
-          ls -ld /home/node/$$VOL
-        done
-
-
-
   webui-server-autotest:
-    depends_on:
-      init-frontend-autotest-volumes:
-        condition: service_completed_successfully
-
     image: 'localhost/localhost/answers-frontend-dev:node-22-bookworm'
     profiles: [ frontend-autotest, all ]
     privileged: true
@@ -67,17 +30,13 @@ services:
     #   - '5173:5173'
     networks:
       - agent-poc
-    volumes:
-      - frontend-autotest-home-1:/home/node
-      - frontend-autotest-node-modules-1:/home/node/node-modules-1
+    volumes: []
       ##SRC - ../../dependency-gate/wait_for_resource.sh:/wait_for_resource.sh:ro
       ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       # Mount important script into the container when we are
       # avoiding rebuilding images to capture their latest version.
       ##SRC - ../build/run_webui_server.sh:/run_webui_server.sh:ro
-      # Mounting a local area to use container-installed dependencies
-      ##SRC - frontend-autotest-home-1:/home/node
-      ##SRC - frontend-autotest-node-modules-1:/app/frontend/node_modules
+      
 
     secrets:
       - codebase_seaweedfs_secrets
@@ -89,8 +48,6 @@ services:
 
 volumes:
   frontend-autotest-home-1:
-    driver: local
-  frontend-autotest-node-modules-1:
     driver: local
   frontend-autotest-init-signal-1:
     driver: local


### PR DESCRIPTION
This PR fixes some race conditions and instability issues when launching a new environment.

* The seaweedfs FUSE client is now launched from supervisord. This promotes better monitoring of the critical background process.
* The supervisord process displaces the non-privileged custom-entry-point-nonpriv.sh as the container's primary process. This non-privileged script is launched from supervisord.
* The non-priviledged script now waits for the FUSE file-system to be mounted before proceeding. This solves a race condition
* Some file permissions and ownerships were incorrected and are now fixed.
