### PR TITLE
move port assignments

### DIFF
--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -59,8 +59,6 @@ services:
     env_file:
       - automated-test.env
       - opentelemetry-instrument.env
-    ports: # use if it is necessary to expose the container to the host machine
-      - '8102:8100'
     networks:
       - agent-poc
     volumes:

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -17,8 +17,6 @@ services:
     env_file:
       - backend.env
       - opentelemetry-instrument.env
-    ports: # use if it is necessary to expose the container to the host machine
-      - '8100:8100'
     networks:
       - agent-poc
     volumes:

--- a/services/celery-worker/deploy/common.compose.yml
+++ b/services/celery-worker/deploy/common.compose.yml
@@ -18,8 +18,6 @@ services:
     env_file:
       - backend.env
       - opentelemetry-instrument.env
-    ports: # use if it is necessary to expose the container to the host machine
-      - '28989:8989'
     networks:
       - agent-poc
     volumes:

--- a/services/jaeger/deploy/compose.yml
+++ b/services/jaeger/deploy/compose.yml
@@ -4,11 +4,7 @@ services:
         image: jaegertracing/all-in-one:1.74.0
         profiles: [ jaeger, infrastructure, telemetry, all ]
         ports:
-            - "16686:16686" # Jaeger UI
-            - "14268:14268" # Jaeger HTTP collector
-            - "14250:14250" # Jaeger gRPC collector
-            - "14318:4318" # OTLP HTTP receiver
-            - "14317:4317" # OTLP gRPC receiver
+            - "26686:16686" # Jaeger UI
         command:
             - "--log-level=debug"
         environment:

--- a/services/keycloak/config/init_keycloak.py
+++ b/services/keycloak/config/init_keycloak.py
@@ -193,41 +193,52 @@ def create_realm_if_missing(keycloak_admin, realm_name):
         logger.info(f"Realm {realm_name} already exists.")
 
 def create_client_if_missing(realm_name):
-    """Create the api-client for OIDC authentication."""
+    """Create or update the api-client for OIDC authentication."""
     # Create a fresh connection object for the realm operations
     kc_realm = get_realm_client(KEYCLOAK_URL, realm_name)
     
     clients = kc_realm.get_clients()
-    existing_clients = [c['clientId'] for c in clients]
-    
     client_id = "api-client"
-    if client_id not in existing_clients:
-        logger.info(f"Creating client {client_id} in {realm_name}")
-        kc_realm.create_client(payload={
-            "clientId": client_id,
-            "enabled": True,
-            "standardFlowEnabled": True,
-            "directAccessGrantsEnabled": False,
-            "serviceAccountsEnabled": False,
-            "publicClient": True,
-            "redirectUris": ["http://localhost:5173/*", "http://localhost:80/*", "https://localhost:15173/*", "https://localhost:15173", "https://localhost:15183/*", "https://localhost:15183"],
-            "webOrigins": ["+"],
-            "protocolMappers": [
-                {
-                    "name": "audience-mapper",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-audience-mapper",
-                    "consentRequired": False,
-                    "config": {
-                        "included.client.audience": client_id,
-                        "id.token.claim": "true",
-                        "access.token.claim": "true"
-                    }
+    client_uuid = next((c['id'] for c in clients if c.get('clientId') == client_id), None)
+    
+    client_payload = {
+        "clientId": client_id,
+        "enabled": True,
+        "standardFlowEnabled": True,
+        "directAccessGrantsEnabled": False,
+        "serviceAccountsEnabled": False,
+        "publicClient": True,
+        "redirectUris": [
+            "http://localhost:5173/*", 
+            "http://localhost:80/*", 
+            "https://localhost:25173/*", 
+            "https://localhost:25173", 
+            "https://localhost:25183/*", 
+            "https://localhost:25183"
+        ],
+        "webOrigins": ["+"],
+        "protocolMappers": [
+            {
+                "name": "audience-mapper",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": False,
+                "config": {
+                    "included.client.audience": client_id,
+                    "id.token.claim": "true",
+                    "access.token.claim": "true"
                 }
-            ]
-        })
+            }
+        ]
+    }
+
+    if not client_uuid:
+        logger.info(f"Creating client {client_id} in {realm_name}")
+        kc_realm.create_client(payload=client_payload)
     else:
-        logger.info(f"Client {client_id} already exists in {realm_name}")
+        logger.info(f"Client {client_id} already exists in {realm_name}. Updating configuration...")
+        # Note: update_client takes the UUID as the first argument, not the client_id string
+        kc_realm.update_client(client_id=client_uuid, payload=client_payload)
 
 def create_roles(realm_name, roles):
     """Create roles in the realm."""

--- a/services/otel-collector/deploy/compose.yml
+++ b/services/otel-collector/deploy/compose.yml
@@ -5,13 +5,13 @@ services:
         profiles: [ infrastructure, telemetry, all ]
 
         ports:
-            - "4317:4317" # OTLP gRPC receiver
-            - "4318:4318" # OTLP HTTP receiver
-            - "8889:8889" # Prometheus metrics exporter
-            - "8888:8888" # Collector's own metrics
-            - "9411:9411" # Zipkin receiver
-            - "13133:13133" # Health check endpoint
-            - "1777:1777" # pprof endpoint
+            - "24317:4317" # OTLP gRPC receiver
+            - "24318:4318" # OTLP HTTP receiver
+            - "28889:8889" # Prometheus metrics exporter
+            - "28888:8888" # Collector's own metrics
+            - "29411:9411" # Zipkin receiver
+            - "23133:13133" # Health check endpoint
+            - "21777:1777" # pprof endpoint
             - "55679:55679" # zpages endpoint
         networks:
             - agent-poc

--- a/services/scripts/full_stop.sh
+++ b/services/scripts/full_stop.sh
@@ -30,7 +30,7 @@ else
     exit 1
 fi
 
-docker compose --profile=all down
+docker compose --profile=all down --remove-orphans
 
 EXIT_CODE="$?"
 if [ "$EXIT_CODE" != 0 ]

--- a/services/seaweedfs/deploy/compose.yml
+++ b/services/seaweedfs/deploy/compose.yml
@@ -12,9 +12,9 @@ services:
         # We map 8333 to host 8333 by default to avoid conflict with existing MinIO (9000).
         # User can change this if they want to replace MinIO completely.
         ports:
-            - '9000:9000'
-            - '9005:9005' # Master port
-            - '9002:9002' # Filer port
+            - '29000:9000'
+            - '29005:9005' # Master port
+            - '29002:9002' # Filer port
 
         networks:
             - agent-poc

--- a/services/traefik/config/traefik.yml
+++ b/services/traefik/config/traefik.yml
@@ -4,7 +4,7 @@ api:
 
 entryPoints:
   web:
-    address: ":15170"
+    address: ":25170"
     http:
       redirections:
         entryPoint:
@@ -12,12 +12,12 @@ entryPoints:
           scheme: https
   
   websecure:
-    address: ":15173"
+    address: ":25173"
     http:
       tls: {}
 
   web-autotest:
-    address: ":15180"
+    address: ":25180"
     http:
       redirections:
         entryPoint:
@@ -25,7 +25,7 @@ entryPoints:
           scheme: https
   
   websecure-autotest:
-    address: ":15183"
+    address: ":25183"
     http:
       tls: {}
 

--- a/services/traefik/deploy/compose.yml
+++ b/services/traefik/deploy/compose.yml
@@ -4,10 +4,10 @@ services:
         profiles: [ traefik, infrastructure, all ]
 
         ports:
-            - '15170:15170'
-            - '15173:15173'
-            - '15180:15180'
-            - '15183:15183'
+            - '25170:25170'
+            - '25173:25173'
+            - '25180:25180'
+            - '25183:25183'
         networks:
             - agent-poc
         volumes:


### PR DESCRIPTION
Moved port assignments from the 10000-19999 to 20000-29999 range.

The reassignment is to help the host machine.

In a few cases, the port assignment was simply removed. These are ports for api-server, celery-worker, and receivers that are directly on Jaeger. The reasoning is that they are a little too internal. If the need for external exposure arises, we can use traefik routes to re-expose.