### PR TITLE
split out document chunks table

### DIFF
--- a/backend/apps/db_migration/alembic/versions/1c2a3f4b5d6e_add_tracked_document_chunks.py
+++ b/backend/apps/db_migration/alembic/versions/1c2a3f4b5d6e_add_tracked_document_chunks.py
@@ -1,0 +1,70 @@
+"""
+Revision ID: 1c2a3f4b5d6e
+Revises: 0b6f9f6fb2f4
+Create Date: 2026-01-25 13:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '1c2a3f4b5d6e'
+down_revision: Union[str, None] = '0b6f9f6fb2f4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Upgrade."""
+    op.create_table(
+        'tracked_document_chunks',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('tracked_document_id', sa.Uuid(), nullable=False),
+        sa.Column('vector_id', sa.String(length=200), nullable=False),
+        sa.Column('page_number', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['tracked_document_id'],
+            ['tracked_documents.id'],
+            name='fk_tracked_document_chunks_document',
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    op.execute('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+    op.execute(
+        """
+        INSERT INTO tracked_document_chunks (id, tracked_document_id, vector_id)
+        SELECT gen_random_uuid(), id, unnest(vector_ids)
+        FROM tracked_documents
+        WHERE vector_ids IS NOT NULL
+        """
+    )
+
+    op.drop_column('tracked_documents', 'vector_ids')
+
+
+def downgrade():
+    """Downgrade."""
+    op.add_column(
+        'tracked_documents',
+        sa.Column('vector_ids', postgresql.ARRAY(sa.String()), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE tracked_documents
+        SET vector_ids = chunk_data.vector_ids
+        FROM (
+            SELECT tracked_document_id, array_agg(vector_id) AS vector_ids
+            FROM tracked_document_chunks
+            GROUP BY tracked_document_id
+        ) AS chunk_data
+        WHERE tracked_documents.id = chunk_data.tracked_document_id
+        """
+    )
+
+    op.drop_table('tracked_document_chunks')

--- a/backend/libs/core/src/core/doc_mgr/doc/delete.py
+++ b/backend/libs/core/src/core/doc_mgr/doc/delete.py
@@ -21,7 +21,7 @@ async def delete_document(document_id):
 
     # Delete vectors from vector store.
 
-    delete_vectors_by_document_id(tracking_record.id)
+    await delete_vectors_by_document_id(tracking_record.id)
 
     logger.info('deleted vectors: %s (%s)', tracking_record.id, tracking_record.source_url)
 

--- a/backend/libs/core/src/core/ingest/ingest.py
+++ b/backend/libs/core/src/core/ingest/ingest.py
@@ -9,6 +9,8 @@ from core_db.db_models import DbTrackedDocument
 from core_db.doc_mgr.doc.query import get_documents
 from core_db.doc_mgr.doc_set.query import get_document_sets
 from core_db.doc_mgr.doc.update import update_tracking_record
+from core_db.doc_mgr.doc_chunk.query import list_document_chunk_vector_ids
+from core_db.doc_mgr.doc_chunk.update import replace_document_chunks
 from core_public import DocumentOcrStrategy, DocumentStatus
 from langchain_core.documents import Document
 from langchain_core.vectorstores import VectorStore
@@ -98,6 +100,7 @@ async def _ingest_one_document(
         updateable_record.status = DocumentStatus.INGESTING
 
     actual_local_path = None
+    local_path = None
     try:
         # We staging the file locally. There are a few good reasons for doing so:
         # 1. We time-separate the file downloads from file processing. If any bad network
@@ -145,6 +148,7 @@ async def _ingest_one_document(
         # will represent a partially processed file while the file is
         # being processed.
         new_vector_ids = []
+        chunk_data = []
 
         document_chunks = []
         batch_size = 10
@@ -161,11 +165,27 @@ async def _ingest_one_document(
             if len(document_chunks) >= batch_size:
                 ids = vector_store.add_documents(documents=document_chunks)
                 new_vector_ids.extend(ids)
+                for doc_chunk, vector_id in zip(document_chunks, ids, strict=False):
+                    page_number = doc_chunk.metadata.get('page_number')
+                    if page_number is not None:
+                        try:
+                            page_number = int(page_number)
+                        except (TypeError, ValueError):
+                            page_number = None
+                    chunk_data.append((vector_id, page_number))
                 document_chunks = []
 
         if len(document_chunks) > 0:
             ids = vector_store.add_documents(documents=document_chunks)
             new_vector_ids.extend(ids)
+            for doc_chunk, vector_id in zip(document_chunks, ids, strict=False):
+                page_number = doc_chunk.metadata.get('page_number')
+                if page_number is not None:
+                    try:
+                        page_number = int(page_number)
+                    except (TypeError, ValueError):
+                        page_number = None
+                chunk_data.append((vector_id, page_number))
             document_chunks = []
 
         # Update the tracking store.
@@ -173,24 +193,22 @@ async def _ingest_one_document(
         # remove orphans earlier in case re-processing a file resulted in identical
         # vectors to the prior processing.
 
+        prior_vector_ids = await list_document_chunk_vector_ids(detached_record.id)
+
         async with update_tracking_record(doc_uuid=detached_record.id) as updateable_record:
             if updateable_record is None:
                 # The tracking record should exist when operations are normal: this big function
                 # started with a verification that the tracking record existed.
                 logger.warning('tracking record %s was deleted elsewhere', detached_record.id)
 
-                delete_vectors_by_document_id(detached_record.id)
+                await delete_vectors_by_document_id(detached_record.id)
 
                 return
 
             updateable_record.status = DocumentStatus.INGESTED
             updateable_record.ingested_time = func.current_timestamp()
 
-            if updateable_record.vector_ids is None:
-                updateable_record.vector_ids = []
-            prior_vector_ids = list(updateable_record.vector_ids)
-
-            updateable_record.vector_ids.extend(new_vector_ids)
+            await replace_document_chunks(detached_record.id, chunk_data)
 
         logger.info('stored %d vectors regarding %s', len(new_vector_ids), rel_path)
 
@@ -211,7 +229,7 @@ async def _ingest_one_document(
                 # the beginning of this function tested for existance.
                 logger.warning('tracking record %s was deleted elsewhere', detached_record.id)
 
-                delete_vectors_by_document_id(detached_record.id)
+                await delete_vectors_by_document_id(detached_record.id)
 
                 return
 

--- a/backend/libs/core/src/core/providers/vector_store/pgvector.py
+++ b/backend/libs/core/src/core/providers/vector_store/pgvector.py
@@ -1,13 +1,15 @@
 """This provides the vector store used by this application."""
 
 import logging
-import uuid
 from functools import cache
 
-from core_db.providers.sql_database import DataDomain, get_async_engine, get_async_sessionmaker, ping_async_sql_database
+import uuid
+
+from core_db.doc_mgr.doc_chunk.query import list_document_chunk_vector_ids
+from core_db.providers.sql_database import DataDomain, get_async_engine, ping_async_sql_database
 from core_public.status_models import PingResult
 from langchain_postgres import PGVector
-from sqlalchemy import MetaData, select
+from sqlalchemy import MetaData
 
 from ...lib_config import get_lib_config
 from ...signals import reset_data_handler, start_up_handler
@@ -90,24 +92,10 @@ async def find_vectors_by_document_id(doc_id: uuid.UUID):
     """
     Find vector embedding UUIDs associated with a specific document ID.
 
-    Returns a list of vector embedding UUID strings that belong to the specified parent document by
-    querying the custom metadata field 'parent_document_id'.
+    Returns a list of vector embedding UUID strings that belong to the specified tracked document by
+    querying the tracked document chunks table.
     """
-    embedding_table = await _get_reflected_embedding_table()
-
-    sessionmaker = get_async_sessionmaker(DataDomain.ANSWERS)
-
-    async with sessionmaker() as session:
-        # Build a select statement filtering on cmetadata ->> 'parent_document_id'
-        stmt = select(embedding_table.c.uuid).where(
-            embedding_table.c.cmetadata.op('->>')('parent_document_id') == str(doc_id)
-        )
-
-        # Execute the query
-        result = await session.execute(stmt)
-
-        # `fetchall` must be called inside the session context.
-        return [str(row[0]) for row in result.fetchall()]
+    return await list_document_chunk_vector_ids(doc_id)
 
 
 async def delete_vectors_by_document_id(doc_id: uuid.UUID):

--- a/backend/libs/core/src/core/providers/vector_store/weaviate.py
+++ b/backend/libs/core/src/core/providers/vector_store/weaviate.py
@@ -9,7 +9,7 @@ from langchain_weaviate import WeaviateVectorStore
 from weaviate import connect_to_local
 from weaviate.classes.config import Configure, DataType, Property, Tokenization, VectorDistances, VectorFilterStrategy
 from weaviate.classes.init import AdditionalConfig, Auth, Timeout
-from weaviate.classes.query import Filter
+from core_db.doc_mgr.doc_chunk.query import list_document_chunk_vector_ids
 
 from ...lib_config import get_lib_config
 from ...signals import reset_data_handler, start_up_handler
@@ -177,41 +177,24 @@ def get_vector_store():
     return vector_store
 
 
-def find_vectors_by_document_id(doc_id: uuid.UUID):
+async def find_vectors_by_document_id(doc_id: uuid.UUID):
     """
     Find vector embedding UUIDs associated with a specific document ID.
 
-    Returns a list of vector embedding UUID strings that belong to the specified parent document by
-    querying the custom metadata field 'parent_document_id'.
+    Returns a list of vector embedding UUID strings that belong to the specified tracked document by
+    querying the tracked document chunks table.
     """
-    collection = _get_collection()
-
-    ids = []
-    batch_size = 50
-    offset = 0
-    while True:
-        query_response = collection.query.fetch_objects(
-            filters=Filter.by_property('document_id').equal(str(doc_id)), limit=batch_size, offset=offset
-        )
-
-        if len(query_response.objects) == 0:
-            break
-
-        batch_ids = [obj.uuid for obj in query_response.objects]
-        ids.extend(batch_ids)
-        offset = offset + batch_size
-
-    return ids
+    return await list_document_chunk_vector_ids(doc_id)
 
 
-def delete_vectors_by_document_id(doc_id: uuid.UUID):
+async def delete_vectors_by_document_id(doc_id: uuid.UUID):
     """
     Delete all vector embeddings associated with a specific document ID.
 
     Finds and removes all vector embeddings that belong to the specified parent document from the
     vector store by first querying for their IDs.
     """
-    vector_ids = find_vectors_by_document_id(doc_id)
+    vector_ids = await find_vectors_by_document_id(doc_id)
 
     vector_store = get_vector_store()
 

--- a/backend/libs/core_db/src/core_db/db_models/__init__.py
+++ b/backend/libs/core_db/src/core_db/db_models/__init__.py
@@ -1,7 +1,14 @@
 # Importing event_handlers will register its start-up event handler.
 from .base import DECLARED_METADATA
-from .doc_mgr import DbTrackedDocument, DbTrackedDocumentSet
+from .doc_mgr import DbTrackedDocument, DbTrackedDocumentChunk, DbTrackedDocumentSet
 from .prompt_mgr import DbPrompt, DbPromptVersion
 
 # Explicitly define the exported names: these names are the contract of this module.
-__all__ = ['DECLARED_METADATA', 'DbTrackedDocument', 'DbTrackedDocumentSet', 'DbPrompt', 'DbPromptVersion']
+__all__ = [
+    'DECLARED_METADATA',
+    'DbTrackedDocument',
+    'DbTrackedDocumentChunk',
+    'DbTrackedDocumentSet',
+    'DbPrompt',
+    'DbPromptVersion',
+]

--- a/backend/libs/core_db/src/core_db/db_models/doc_mgr.py
+++ b/backend/libs/core_db/src/core_db/db_models/doc_mgr.py
@@ -4,8 +4,6 @@ import uuid
 
 from core_public import DocumentStatus
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid
-from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql.functions import current_timestamp
 
@@ -80,9 +78,6 @@ class DbTrackedDocument(Base):
     ocr_strategy: Mapped[str] = mapped_column(String(32), nullable=False, server_default='use_document_set')
 
     s3_rel_path: Mapped[str] = mapped_column(String(800), nullable=False)
-    # https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html
-    # and https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.ARRAY
-    vector_ids: Mapped[list[str]] = mapped_column(MutableList.as_mutable(ARRAY(String)), nullable=True)
     ingested_time: Mapped[datetime.datetime] = mapped_column(DateTime, nullable=True)
 
     # Used to track the last user who acted on this document.
@@ -103,3 +98,43 @@ class DbTrackedDocument(Base):
 
     # Define the relationship to TrackedDocumentSet
     document_set: Mapped['DbTrackedDocumentSet'] = relationship(back_populates='documents')
+
+    # Define the relationship to tracked document chunks
+    chunks: Mapped[list['DbTrackedDocumentChunk']] = relationship(
+        order_by='DbTrackedDocumentChunk.id', back_populates='tracked_document', cascade='all, delete-orphan'
+    )
+
+
+class DbTrackedDocumentChunk(Base):
+    """
+    SQLAlchemy model representing a tracked document chunk in the database.
+
+    Stores vector store IDs for chunks along with optional page number metadata.
+    """
+
+    __tablename__ = 'tracked_document_chunks'
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True)
+    tracked_document_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey(f'{DbTrackedDocument.__tablename__}.id', ondelete='CASCADE')
+    )
+    vector_id: Mapped[str] = mapped_column(String(200), nullable=False)
+    page_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Used to track the last user who acted on this document.
+    last_user_id: Mapped[uuid.UUID] = mapped_column(Uuid, nullable=True)
+
+    # 1. `server_default` means that the value is set inside the "CREATE TABLE" statement
+    #    by defining a default value that calls the current_timestamp function.
+    # 2. `onupdate` means that the value is set within the "UPDATE" statement.
+    #
+    # See https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.server_default
+    # and https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.onupdate
+    # and https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.server_onupdate.
+    #
+    create_time: Mapped[datetime.datetime] = mapped_column(DateTime, server_default=current_timestamp())
+    update_time: Mapped[datetime.datetime] = mapped_column(
+        DateTime, server_default=current_timestamp(), onupdate=current_timestamp(), nullable=True
+    )
+
+    tracked_document: Mapped['DbTrackedDocument'] = relationship(back_populates='chunks')

--- a/backend/libs/core_db/src/core_db/doc_mgr/doc/update.py
+++ b/backend/libs/core_db/src/core_db/doc_mgr/doc/update.py
@@ -3,7 +3,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 from sqlalchemy import select
-from sqlalchemy.orm import undefer
+from sqlalchemy.orm import selectinload
 
 from core_db.db_models import DbTrackedDocument
 from core_db.providers.sql_database import DataDomain, get_async_sessionmaker
@@ -21,20 +21,9 @@ async def update_tracking_record(doc_uuid):
 
     async with sessionmaker() as session:
         async with session.begin():
-            # Fix for MissingGreenlet error during attribute access.
-            #
-            # * Expectation: `select(DbTrackedDocument)` eagerly loads all columns.
-            # * Reality: The `vector_ids` column (MutableList of ARRAY) was being deferred or considered expired,
-            #   causing a lazy load upon access.
-            #
-            # The visible `MissingGreenlet` error is caused by SQLAlchemy attempting to perform a synchronous
-            # lazy load (and potentially an autoflush) when `vector_ids` is accessed. This fails because
-            # the operation is running in an async session without the necessary greenlet context.
-            # Adding `undefer` forces the column to be loaded immediately in the initial query, avoiding
-            # the lazy load and the resulting error.
             stmt = (
                 select(DbTrackedDocument)
-                .options(undefer(DbTrackedDocument.vector_ids))
+                .options(selectinload(DbTrackedDocument.chunks))
                 .where(DbTrackedDocument.id == doc_uuid)
             )
             result = await session.execute(stmt)

--- a/backend/libs/core_db/src/core_db/doc_mgr/doc_chunk/query.py
+++ b/backend/libs/core_db/src/core_db/doc_mgr/doc_chunk/query.py
@@ -1,0 +1,33 @@
+import uuid
+from typing import Sequence
+
+from sqlalchemy import select
+
+from core_db.db_models import DbTrackedDocumentChunk
+from core_db.providers.sql_database import DataDomain, get_async_sessionmaker
+
+
+async def list_document_chunks(doc_uuid: uuid.UUID | str) -> Sequence[DbTrackedDocumentChunk]:
+    """Return tracked document chunks for a document."""
+    if isinstance(doc_uuid, str):
+        doc_uuid = uuid.UUID(hex=doc_uuid)
+
+    sessionmaker = get_async_sessionmaker(DataDomain.ANSWERS)
+
+    async with sessionmaker() as session:
+        stmt = select(DbTrackedDocumentChunk).where(DbTrackedDocumentChunk.tracked_document_id == doc_uuid)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+
+async def list_document_chunk_vector_ids(doc_uuid: uuid.UUID | str) -> list[str]:
+    """Return vector IDs for tracked document chunks."""
+    if isinstance(doc_uuid, str):
+        doc_uuid = uuid.UUID(hex=doc_uuid)
+
+    sessionmaker = get_async_sessionmaker(DataDomain.ANSWERS)
+
+    async with sessionmaker() as session:
+        stmt = select(DbTrackedDocumentChunk.vector_id).where(DbTrackedDocumentChunk.tracked_document_id == doc_uuid)
+        result = await session.execute(stmt)
+        return [row[0] for row in result.fetchall()]

--- a/backend/libs/core_db/src/core_db/doc_mgr/doc_chunk/update.py
+++ b/backend/libs/core_db/src/core_db/doc_mgr/doc_chunk/update.py
@@ -1,0 +1,34 @@
+import uuid
+from typing import Iterable
+
+from sqlalchemy import delete
+
+from core_db.db_models import DbTrackedDocumentChunk
+from core_db.providers.sql_database import DataDomain, get_async_sessionmaker
+
+
+async def replace_document_chunks(
+    doc_uuid: uuid.UUID | str,
+    chunk_data: Iterable[tuple[str, int | None]],
+) -> None:
+    """Replace tracked document chunks for a document."""
+    if isinstance(doc_uuid, str):
+        doc_uuid = uuid.UUID(hex=doc_uuid)
+
+    sessionmaker = get_async_sessionmaker(DataDomain.ANSWERS)
+
+    async with sessionmaker() as session:
+        async with session.begin():
+            await session.execute(
+                delete(DbTrackedDocumentChunk).where(DbTrackedDocumentChunk.tracked_document_id == doc_uuid)
+            )
+
+            for vector_id, page_number in chunk_data:
+                session.add(
+                    DbTrackedDocumentChunk(
+                        id=uuid.uuid4(),
+                        tracked_document_id=doc_uuid,
+                        vector_id=vector_id,
+                        page_number=page_number,
+                    )
+                )

--- a/backend/libs/core_db/tests/doc_mgr/test_lazy_loading.py
+++ b/backend/libs/core_db/tests/doc_mgr/test_lazy_loading.py
@@ -2,20 +2,19 @@
 import pytest
 import uuid
 import datetime
-from core_db.db_models.doc_mgr import DbTrackedDocument, DbTrackedDocumentSet
+from core_db.db_models.doc_mgr import DbTrackedDocument, DbTrackedDocumentChunk, DbTrackedDocumentSet
 from core_public import DocumentStatus
 from core_db.doc_mgr.doc.update import update_tracking_record
 
 @pytest.mark.asyncio
-async def test_vector_ids_lazy_loading_fix(async_session):
+async def test_document_chunks_lazy_loading_fix(async_session):
     """
-    Regression test for MissingGreenlet error when accessing vector_ids.
+    Regression test for MissingGreenlet error when accessing document chunks.
     
-    The issue was that vector_ids (MutableList of ARRAY) was being deferred,
-    causing a synchronous lazy load attempt inside an async session when accessed,
-    especially after a status change triggered an autoflush.
-    
-    The fix involved adding `undefer(DbTrackedDocument.vector_ids)` to the query.
+    The issue was that accessing related chunks could cause a synchronous lazy load attempt inside
+    an async session when accessed, especially after a status change triggered an autoflush.
+
+    The fix involved eager loading the chunk relationship in the tracking record query.
     """
     # Setup
     doc_set_id = uuid.uuid4()
@@ -40,9 +39,25 @@ async def test_vector_ids_lazy_loading_fix(async_session):
         source_url="http://example.com",
         content_type="text/plain",
         s3_rel_path="test.txt",
-        vector_ids=["a", "b"]
     )
     async_session.add(doc)
+
+    async_session.add_all(
+        [
+            DbTrackedDocumentChunk(
+                id=uuid.uuid4(),
+                tracked_document_id=doc_id,
+                vector_id="a",
+                page_number=None,
+            ),
+            DbTrackedDocumentChunk(
+                id=uuid.uuid4(),
+                tracked_document_id=doc_id,
+                vector_id="b",
+                page_number=1,
+            ),
+        ]
+    )
     await async_session.commit()
     
     try:
@@ -53,17 +68,20 @@ async def test_vector_ids_lazy_loading_fix(async_session):
             # Modify a field to trigger potential autoflush on next access
             updateable_record.status = DocumentStatus.INGESTED
             
-            # Access vector_ids
-            # Without the fix (undefer), this would raise MissingGreenlet
+            # Access chunks
+            # Without eager loading, this could raise MissingGreenlet
             # With the fix, it should work
-            vector_ids = updateable_record.vector_ids
-            assert vector_ids == ["a", "b"]
+            chunk_vector_ids = sorted(chunk.vector_id for chunk in updateable_record.chunks)
+            assert chunk_vector_ids == ["a", "b"]
             
     finally:
         # Cleanup
         # We need to merge them back into the session to delete because they might be detached
         # or we can just delete by ID
         from sqlalchemy import delete
+        await async_session.execute(
+            delete(DbTrackedDocumentChunk).where(DbTrackedDocumentChunk.tracked_document_id == doc_id)
+        )
         await async_session.execute(delete(DbTrackedDocument).where(DbTrackedDocument.id == doc_id))
         await async_session.execute(delete(DbTrackedDocumentSet).where(DbTrackedDocumentSet.id == doc_set_id))
         await async_session.commit()


### PR DESCRIPTION
The document table's vector-ids column (of type ARRAY) is replaced with a  standard relational table for document-chunks. 
Each vector-id now has its own row in the document-chunk table. An optional page number column is in the document-chunk table.

The application logic is realigned to this new database model.