### PR TITLE
get vitest and pytest working as run-and-exit jobs

### DIFF
--- a/backend/libs/core/tests/__init__.py
+++ b/backend/libs/core/tests/__init__.py
@@ -1,1 +1,0 @@
-# Empty __init__.py is still useful. It signals that this directory is a Python package.

--- a/backend/libs/core/tests/conftest.py
+++ b/backend/libs/core/tests/conftest.py
@@ -1,35 +1,34 @@
-# The conftest.py file provides fixtures for an entire directory.
 # Import fixture modules so pytest will register fixtures defined in them
 # (for example: tests/fixtures/api.py defines `api_server`).
 
-from .fixtures.api import api_server, global_reset
-from .fixtures.db import (
+from libs.core.tests.fixtures.api import api_server, global_reset
+from libs.core.tests.fixtures.db import (
     auto_mapped_classes,
     get_connection_str,
     reflected_metadata,
     sql_engine,
     sql_sessionmaker,
 )
-from .fixtures.doc import (
+from libs.core.tests.fixtures.doc import (
     doc_table,
     empty_doc_table,
     ingested_doc_table,
     populated_doc_table,
 )
-from .fixtures.doc_set import (
+from libs.core.tests.fixtures.doc_set import (
     doc_set_table,
     empty_doc_set_table,
     populated_doc_set_table,
     readonly_doc_set_table,
 )
-from .fixtures.prompt import (
+from libs.core.tests.fixtures.prompt import (
     empty_prompt_table,
     populated_prompt_table,
     prompt_table,
 )
-from .fixtures.prompt_version import (
+from libs.core.tests.fixtures.prompt_version import (
     empty_prompt_version_table,
     populated_prompt_version_table,
     prompt_version_table,
 )
-from .fixtures.s3 import s3_bucket, s3_client
+from libs.core.tests.fixtures.s3 import s3_bucket, s3_client

--- a/backend/libs/core_db/tests/__init__.py
+++ b/backend/libs/core_db/tests/__init__.py
@@ -1,1 +1,0 @@
-# Empty __init__.py is still useful. It signals that this directory is a Python package.

--- a/backend/libs/core_db/tests/conftest.py
+++ b/backend/libs/core_db/tests/conftest.py
@@ -2,7 +2,7 @@
 # Import fixture modules so pytest will register fixtures defined in them
 # (for example: tests/fixtures/api.py defines `api_server`).
 
-from .fixtures.db import (
+from libs.core_db.tests.fixtures.db import (
     async_engine,
     async_session,
     get_connection_str,

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -15,11 +15,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 #
 asyncio_default_fixture_loop_scope = module
 
-testpaths =
-    tests/answers
-
-# Additional pytest options
-## addopts = --ignore=tests/doc_mgr/doc/test_ingest.py --ignore=tests/answers
+pythonpath = .
 
 # Ignore these directories when discovering tests.
-norecursedirs = ["tests/doc_mgr", "tests/prompt_mgr"]
+## norecursedirs = ["tests/doc_mgr", "tests/prompt_mgr"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "demo-frontend",
+    "name": "webui-server",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "demo-frontend",
+            "name": "webui-server",
             "version": "0.0.0",
             "dependencies": {
                 "@mdi/font": "^7.4.47",
@@ -15,23 +15,34 @@
                 "marked": "^15.0.6",
                 "mermaid": "^11.12.0",
                 "oidc-client-ts": "^3.0.1",
-                "pinia": "^2.3.1",
-                "pinia-plugin-persistedstate": "^3.2.0",
+                "pinia": "^3.0.4",
+                "pinia-plugin-persistedstate": "^4.7.1",
                 "vue": "^3.5.13",
                 "vue-router": "^4.5.0",
                 "vuetify": "^3.7.7"
             },
             "devDependencies": {
                 "@eslint/js": "^9.27.0",
+                "@pinia/testing": "^1.0.3",
                 "@vitejs/plugin-vue": "^5.2.1",
+                "@vue/test-utils": "^2.4.6",
                 "eslint": "^9.19.0",
                 "eslint-config-prettier": "^10.1.5",
                 "eslint-plugin-prettier": "^5.4.0",
                 "eslint-plugin-vue": "^9.33.0",
                 "globals": "^16.1.0",
+                "jsdom": "^27.4.0",
                 "vite": "^5.4.19",
-                "vite-plugin-vue-devtools": "^7.7.1"
+                "vite-plugin-vue-devtools": "^7.7.1",
+                "vitest": "^4.0.18"
             }
+        },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@antfu/install-pkg": {
             "version": "1.1.0",
@@ -55,6 +66,41 @@
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+            "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-color-parser": "^3.1.0",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "lru-cache": "^11.2.4"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.7.6",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+            "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.4"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.28.6",
@@ -167,6 +213,16 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -598,6 +654,138 @@
             "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
             "license": "Apache-2.0"
         },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.0.26",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+            "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0"
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -887,6 +1075,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -904,6 +1109,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -919,6 +1141,23 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -1146,6 +1385,24 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@exodus/bytes": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.9.0.tgz",
+            "integrity": "sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1215,6 +1472,24 @@
                 "mlly": "^1.8.0"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1279,6 +1554,37 @@
                 "langium": "3.3.1"
             }
         },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@pinia/testing": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.3.tgz",
+            "integrity": "sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "pinia": ">=3.0.4"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1323,9 +1629,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-            "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
+            "integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
             "cpu": [
                 "arm"
             ],
@@ -1337,9 +1643,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-            "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
+            "integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1351,9 +1657,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-            "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
+            "integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
             "cpu": [
                 "arm64"
             ],
@@ -1365,9 +1671,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-            "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
+            "integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
             "cpu": [
                 "x64"
             ],
@@ -1379,9 +1685,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-            "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
+            "integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1393,9 +1699,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-            "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
+            "integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
             "cpu": [
                 "x64"
             ],
@@ -1407,9 +1713,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-            "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
+            "integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
             "cpu": [
                 "arm"
             ],
@@ -1421,9 +1727,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-            "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
+            "integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
             "cpu": [
                 "arm"
             ],
@@ -1435,9 +1741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-            "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
+            "integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1449,9 +1755,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-            "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
+            "integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
             "cpu": [
                 "arm64"
             ],
@@ -1463,9 +1769,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-            "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
+            "integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
             "cpu": [
                 "loong64"
             ],
@@ -1477,9 +1783,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-            "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
+            "integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
             "cpu": [
                 "loong64"
             ],
@@ -1491,9 +1797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-            "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
+            "integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1505,9 +1811,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-            "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
+            "integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1519,9 +1825,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-            "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
+            "integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
             "cpu": [
                 "riscv64"
             ],
@@ -1533,9 +1839,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-            "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
+            "integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1547,9 +1853,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-            "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
+            "integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1561,9 +1867,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-            "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
+            "integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
             "cpu": [
                 "x64"
             ],
@@ -1575,9 +1881,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-            "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
+            "integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
             "cpu": [
                 "x64"
             ],
@@ -1589,9 +1895,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-            "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
+            "integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
             "cpu": [
                 "x64"
             ],
@@ -1603,9 +1909,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-            "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
+            "integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1617,9 +1923,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-            "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
+            "integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
             "cpu": [
                 "arm64"
             ],
@@ -1631,9 +1937,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-            "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
+            "integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
             "cpu": [
                 "ia32"
             ],
@@ -1645,9 +1951,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-            "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
+            "integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
             "cpu": [
                 "x64"
             ],
@@ -1659,9 +1965,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-            "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
+            "integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
             "cpu": [
                 "x64"
             ],
@@ -1690,6 +1996,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/d3": {
@@ -1945,6 +2269,13 @@
                 "@types/d3-selection": "*"
             }
         },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1996,6 +2327,90 @@
             "peerDependencies": {
                 "vite": "^5.0.0 || ^6.0.0",
                 "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+            "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.0.18",
+                "@vitest/utils": "4.0.18",
+                "chai": "^6.2.1",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+            "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+            "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.0.18",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+            "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.0.18",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+            "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+            "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.0.18",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vue/babel-helper-vue-transform-on": {
@@ -2052,39 +2467,51 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
-            "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+            "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.5",
-                "@vue/shared": "3.5.26",
+                "@vue/shared": "3.5.27",
                 "entities": "^7.0.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
-            "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+            "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-core": "3.5.27",
+                "@vue/shared": "3.5.27"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
-            "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+            "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.5",
-                "@vue/compiler-core": "3.5.26",
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/compiler-ssr": "3.5.26",
-                "@vue/shared": "3.5.26",
+                "@vue/compiler-core": "3.5.27",
+                "@vue/compiler-dom": "3.5.27",
+                "@vue/compiler-ssr": "3.5.27",
+                "@vue/shared": "3.5.27",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
                 "postcss": "^8.5.6",
@@ -2092,20 +2519,23 @@
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
-            "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+            "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-dom": "3.5.27",
+                "@vue/shared": "3.5.27"
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "6.6.4",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-            "license": "MIT"
+            "version": "7.7.9",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+            "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-kit": "^7.7.9"
+            }
         },
         "node_modules/@vue/devtools-core": {
             "version": "7.7.9",
@@ -2148,7 +2578,6 @@
             "version": "7.7.9",
             "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
             "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/devtools-shared": "^7.7.9",
@@ -2164,61 +2593,71 @@
             "version": "7.7.9",
             "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
             "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
-            "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+            "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.26"
+                "@vue/shared": "3.5.27"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
-            "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+            "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/reactivity": "3.5.27",
+                "@vue/shared": "3.5.27"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
-            "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+            "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.26",
-                "@vue/runtime-core": "3.5.26",
-                "@vue/shared": "3.5.26",
+                "@vue/reactivity": "3.5.27",
+                "@vue/runtime-core": "3.5.27",
+                "@vue/shared": "3.5.27",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
-            "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+            "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-ssr": "3.5.27",
+                "@vue/shared": "3.5.27"
             },
             "peerDependencies": {
-                "vue": "3.5.26"
+                "vue": "3.5.27"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
-            "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+            "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
             "license": "MIT"
+        },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+            "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^2.0.0"
+            }
         },
         "node_modules/@vueuse/core": {
             "version": "12.8.2",
@@ -2256,6 +2695,16 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
+        "node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2278,6 +2727,16 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2293,6 +2752,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
@@ -2318,6 +2790,16 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2326,20 +2808,29 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.15",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
-            "integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+            "version": "2.9.18",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
+            "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
         "node_modules/birpc": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
             "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -2424,9 +2915,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001764",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-            "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+            "version": "1.0.30001766",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+            "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
             "dev": true,
             "funding": [
                 {
@@ -2443,6 +2934,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2514,12 +3015,13 @@
             "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">=14"
             }
         },
         "node_modules/concat-map": {
@@ -2535,6 +3037,17 @@
             "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
             "license": "MIT"
         },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2546,7 +3059,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
             "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-what": "^5.2.0"
@@ -2582,6 +3094,20 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.12.2",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2593,6 +3119,22 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/cssstyle": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+            "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^4.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/csstype": {
@@ -2817,6 +3359,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/d3-ease": {
@@ -3100,6 +3651,30 @@
                 "lodash-es": "^4.17.21"
             }
         },
+        "node_modules/data-urls": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+            "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^15.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/dayjs": {
             "version": "1.11.19",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -3123,6 +3698,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -3174,6 +3756,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/defu": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+            "license": "MIT"
+        },
         "node_modules/delaunator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -3192,17 +3780,77 @@
                 "@types/trusted-types": "^2.0.7"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+            "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/editorconfig/node_modules/minimatch": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+            "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.267",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-            "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+            "version": "1.5.278",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.278.tgz",
+            "integrity": "sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw==",
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/entities": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-            "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -3220,6 +3868,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.21.5",
@@ -3556,6 +4211,16 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3583,6 +4248,24 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/figures": {
             "version": "6.1.0",
@@ -3651,6 +4334,23 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/fs-extra": {
             "version": "11.3.3",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
@@ -3708,6 +4408,27 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3719,6 +4440,32 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globals": {
@@ -3761,8 +4508,48 @@
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
             "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/human-signals": {
             "version": "8.0.1",
@@ -3823,6 +4610,13 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/internmap": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3856,6 +4650,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-glob": {
@@ -3903,6 +4707,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-stream": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -3933,7 +4744,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
             "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -3965,6 +4775,54 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3983,6 +4841,56 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "27.4.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+            "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.28",
+                "@asamuzakjp/dom-selector": "^6.7.6",
+                "@exodus/bytes": "^1.6.0",
+                "cssstyle": "^5.3.4",
+                "data-urls": "^6.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.0",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^15.1.0",
+                "ws": "^8.18.3",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/jsesc": {
@@ -4055,9 +4963,9 @@
             }
         },
         "node_modules/katex": {
-            "version": "0.16.27",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
-            "integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+            "version": "0.16.28",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+            "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
             "funding": [
                 "https://opencollective.com/katex",
                 "https://github.com/sponsors/katex"
@@ -4154,16 +5062,16 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.22",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-            "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -4187,13 +5095,13 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "version": "11.2.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/magic-string": {
@@ -4216,6 +5124,13 @@
             "engines": {
                 "node": ">= 18"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/mermaid": {
             "version": "11.12.2",
@@ -4270,11 +5185,20 @@
                 "node": "*"
             }
         },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mlly": {
@@ -4338,6 +5262,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/npm-run-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -4380,6 +5320,17 @@
             "funding": {
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/oidc-client-ts": {
             "version": "3.4.1",
@@ -4462,6 +5413,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/package-manager-detector": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -4494,6 +5452,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse5": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/path-data-parser": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -4520,6 +5491,30 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/pathe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4530,7 +5525,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -4553,20 +5547,19 @@
             }
         },
         "node_modules/pinia": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
-            "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+            "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-api": "^6.6.3",
-                "vue-demi": "^0.14.10"
+                "@vue/devtools-api": "^7.7.7"
             },
             "funding": {
                 "url": "https://github.com/sponsors/posva"
             },
             "peerDependencies": {
-                "typescript": ">=4.4.4",
-                "vue": "^2.7.0 || ^3.5.11"
+                "typescript": ">=4.5.0",
+                "vue": "^3.5.11"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4575,12 +5568,28 @@
             }
         },
         "node_modules/pinia-plugin-persistedstate": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.3.tgz",
-            "integrity": "sha512-Cm819WBj/s5K5DGw55EwbXDtx+EZzM0YR5AZbq9XE3u0xvXwvX2JnWoFpWIcdzISBHqy9H1UiSIUmXyXqWsQRQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-4.7.1.tgz",
+            "integrity": "sha512-WHOqh2esDlR3eAaknPbqXrkkj0D24h8shrDPqysgCFR6ghqP/fpFfJmMPJp0gETHsvrh9YNNg6dQfo2OEtDnIQ==",
             "license": "MIT",
+            "dependencies": {
+                "defu": "^6.1.4"
+            },
             "peerDependencies": {
-                "pinia": "^2.0.0"
+                "@nuxt/kit": ">=3.0.0",
+                "@pinia/nuxt": ">=0.10.0",
+                "pinia": ">=3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@nuxt/kit": {
+                    "optional": true
+                },
+                "@pinia/nuxt": {
+                    "optional": true
+                },
+                "pinia": {
+                    "optional": true
+                }
             }
         },
         "node_modules/pkg-types": {
@@ -4663,9 +5672,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-            "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4708,6 +5717,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4716,6 +5732,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/resolve-from": {
@@ -4732,7 +5758,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/robust-predicates": {
@@ -4742,9 +5767,9 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-            "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+            "version": "4.56.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
+            "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4758,31 +5783,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.55.1",
-                "@rollup/rollup-android-arm64": "4.55.1",
-                "@rollup/rollup-darwin-arm64": "4.55.1",
-                "@rollup/rollup-darwin-x64": "4.55.1",
-                "@rollup/rollup-freebsd-arm64": "4.55.1",
-                "@rollup/rollup-freebsd-x64": "4.55.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.55.1",
-                "@rollup/rollup-linux-arm64-musl": "4.55.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.55.1",
-                "@rollup/rollup-linux-loong64-musl": "4.55.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.55.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.55.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.55.1",
-                "@rollup/rollup-linux-x64-gnu": "4.55.1",
-                "@rollup/rollup-linux-x64-musl": "4.55.1",
-                "@rollup/rollup-openbsd-x64": "4.55.1",
-                "@rollup/rollup-openharmony-arm64": "4.55.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.55.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.55.1",
-                "@rollup/rollup-win32-x64-gnu": "4.55.1",
-                "@rollup/rollup-win32-x64-msvc": "4.55.1",
+                "@rollup/rollup-android-arm-eabi": "4.56.0",
+                "@rollup/rollup-android-arm64": "4.56.0",
+                "@rollup/rollup-darwin-arm64": "4.56.0",
+                "@rollup/rollup-darwin-x64": "4.56.0",
+                "@rollup/rollup-freebsd-arm64": "4.56.0",
+                "@rollup/rollup-freebsd-x64": "4.56.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.56.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.56.0",
+                "@rollup/rollup-linux-arm64-musl": "4.56.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.56.0",
+                "@rollup/rollup-linux-loong64-musl": "4.56.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.56.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.56.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.56.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.56.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.56.0",
+                "@rollup/rollup-linux-x64-gnu": "4.56.0",
+                "@rollup/rollup-linux-x64-musl": "4.56.0",
+                "@rollup/rollup-openbsd-x64": "4.56.0",
+                "@rollup/rollup-openharmony-arm64": "4.56.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.56.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.56.0",
+                "@rollup/rollup-win32-x64-gnu": "4.56.0",
+                "@rollup/rollup-win32-x64-msvc": "4.56.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -4823,6 +5848,19 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/semver": {
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4858,6 +5896,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
@@ -4900,10 +5945,127 @@
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
             "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
@@ -4942,7 +6104,6 @@
             "version": "2.2.6",
             "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
             "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "copy-anything": "^4"
@@ -4964,6 +6125,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/synckit": {
             "version": "0.11.12",
             "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -4980,6 +6148,13 @@
                 "url": "https://opencollective.com/synckit"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyexec": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -4989,6 +6164,53 @@
                 "node": ">=18"
             }
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+            "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+            "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.19"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+            "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/totalist": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -4997,6 +6219,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+            "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/ts-dedent": {
@@ -5272,6 +6520,629 @@
                 "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+            "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.0.18",
+                "@vitest/mocker": "4.0.18",
+                "@vitest/pretty-format": "4.0.18",
+                "@vitest/runner": "4.0.18",
+                "@vitest/snapshot": "4.0.18",
+                "@vitest/spy": "4.0.18",
+                "@vitest/utils": "4.0.18",
+                "es-module-lexer": "^1.7.0",
+                "expect-type": "^1.2.2",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^3.10.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.0.3",
+                "vite": "^6.0.0 || ^7.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.0.18",
+                "@vitest/browser-preview": "4.0.18",
+                "@vitest/browser-webdriverio": "4.0.18",
+                "@vitest/ui": "4.0.18",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "4.0.18",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+            "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.0.18",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.2",
+                "@esbuild/android-arm": "0.27.2",
+                "@esbuild/android-arm64": "0.27.2",
+                "@esbuild/android-x64": "0.27.2",
+                "@esbuild/darwin-arm64": "0.27.2",
+                "@esbuild/darwin-x64": "0.27.2",
+                "@esbuild/freebsd-arm64": "0.27.2",
+                "@esbuild/freebsd-x64": "0.27.2",
+                "@esbuild/linux-arm": "0.27.2",
+                "@esbuild/linux-arm64": "0.27.2",
+                "@esbuild/linux-ia32": "0.27.2",
+                "@esbuild/linux-loong64": "0.27.2",
+                "@esbuild/linux-mips64el": "0.27.2",
+                "@esbuild/linux-ppc64": "0.27.2",
+                "@esbuild/linux-riscv64": "0.27.2",
+                "@esbuild/linux-s390x": "0.27.2",
+                "@esbuild/linux-x64": "0.27.2",
+                "@esbuild/netbsd-arm64": "0.27.2",
+                "@esbuild/netbsd-x64": "0.27.2",
+                "@esbuild/openbsd-arm64": "0.27.2",
+                "@esbuild/openbsd-x64": "0.27.2",
+                "@esbuild/openharmony-arm64": "0.27.2",
+                "@esbuild/sunos-x64": "0.27.2",
+                "@esbuild/win32-arm64": "0.27.2",
+                "@esbuild/win32-ia32": "0.27.2",
+                "@esbuild/win32-x64": "0.27.2"
+            }
+        },
+        "node_modules/vitest/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vscode-jsonrpc": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -5322,16 +7193,16 @@
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.26",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
-            "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+            "version": "3.5.27",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+            "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.26",
-                "@vue/compiler-sfc": "3.5.26",
-                "@vue/runtime-dom": "3.5.26",
-                "@vue/server-renderer": "3.5.26",
-                "@vue/shared": "3.5.26"
+                "@vue/compiler-dom": "3.5.27",
+                "@vue/compiler-sfc": "3.5.27",
+                "@vue/runtime-dom": "3.5.27",
+                "@vue/server-renderer": "3.5.27",
+                "@vue/shared": "3.5.27"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -5342,31 +7213,12 @@
                 }
             }
         },
-        "node_modules/vue-demi": {
-            "version": "0.14.10",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
+        "node_modules/vue-component-type-helpers": {
+            "version": "2.2.12",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+            "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vue-eslint-parser": {
             "version": "9.4.3",
@@ -5456,10 +7308,16 @@
                 "vue": "^3.5.0"
             }
         },
+        "node_modules/vue-router/node_modules/@vue/devtools-api": {
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+            "license": "MIT"
+        },
         "node_modules/vuetify": {
-            "version": "3.11.6",
-            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.11.6.tgz",
-            "integrity": "sha512-vaWvEpDSeldRoib1tCKNVBp60paTD2/n0a0TmrVLF9BN4CJJn6/A4VKG2Sg+DE8Yc+SNOtFtipChxSlQxjcUvw==",
+            "version": "3.11.7",
+            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.11.7.tgz",
+            "integrity": "sha512-3nK1mKTXQRbU4QXukV4WIbs5YZgMK19flHpFq3pU+6Fpa5YLB8RyyK1BLWAW8JmhSVcaqVUcB/EJ3oJ8g3XNCw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -5483,6 +7341,63 @@
                 }
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+            "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5499,6 +7414,23 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5507,6 +7439,123 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/wsl-utils": {
@@ -5534,6 +7583,13 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yallist": {
             "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "demo-frontend",
+    "name": "webui-server",
     "version": "0.0.0",
     "private": true,
     "type": "module",
@@ -11,7 +11,8 @@
         "lint:fix": "eslint \"**/*.{vue,js,jsx,cjs,mjs}\" --fix",
         "lint:verbose": "eslint \"**/*.{vue,js,jsx,cjs,mjs}\" --format json -o eslint-report.json || true",
         "lint:ci": "eslint \"**/*.{vue,js,jsx,cjs,mjs}\" --max-warnings=0",
-        "lint:pretty": "sh -c 'npm run lint:fix -- \"$@\" && npm run lint:verbose && node scripts/format-eslint-json.js eslint-report.json' --"
+        "lint:pretty": "sh -c 'npm run lint:fix -- \"$@\" && npm run lint:verbose && node scripts/format-eslint-json.js eslint-report.json' --",
+        "test:unit": "vitest run"
     },
     "dependencies": {
         "@mdi/font": "^7.4.47",
@@ -21,21 +22,25 @@
         "marked": "^15.0.6",
         "mermaid": "^11.12.0",
         "oidc-client-ts": "^3.0.1",
-        "pinia": "^2.3.1",
-        "pinia-plugin-persistedstate": "^3.2.0",
+        "pinia": "^3.0.4",
+        "pinia-plugin-persistedstate": "^4.7.1",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
         "vuetify": "^3.7.7"
     },
     "devDependencies": {
         "@eslint/js": "^9.27.0",
+        "@pinia/testing": "^1.0.3",
         "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/test-utils": "^2.4.6",
         "eslint": "^9.19.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-vue": "^9.33.0",
         "globals": "^16.1.0",
+        "jsdom": "^27.4.0",
         "vite": "^5.4.19",
-        "vite-plugin-vue-devtools": "^7.7.1"
+        "vite-plugin-vue-devtools": "^7.7.1",
+        "vitest": "^4.0.18"
     }
 }

--- a/frontend/tests/common/AuthUtils.test.js
+++ b/frontend/tests/common/AuthUtils.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getAuthorization } from '@/common/AuthUtils'
+import { authService } from '@/common/AuthService'
+
+// Mock AuthService
+vi.mock('@/common/AuthService', () => ({
+    authService: {
+        getUser: vi.fn(),
+    },
+}))
+
+describe('AuthUtils', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should return Bearer token when user is valid', async () => {
+        authService.getUser.mockResolvedValue({
+            expired: false,
+            access_token: 'fake-token',
+        })
+
+        const authHeader = await getAuthorization()
+        expect(authHeader).toBe('Bearer fake-token')
+    })
+
+    it('should return null when user is null', async () => {
+        authService.getUser.mockResolvedValue(null)
+
+        const authHeader = await getAuthorization()
+        expect(authHeader).toBeNull()
+    })
+
+    it('should return null when user is expired', async () => {
+        authService.getUser.mockResolvedValue({
+            expired: true,
+            access_token: 'fake-token',
+        })
+
+        const authHeader = await getAuthorization()
+        expect(authHeader).toBeNull()
+    })
+
+    it('should return null when access_token is missing', async () => {
+        authService.getUser.mockResolvedValue({
+            expired: false,
+            access_token: null,
+        })
+
+        const authHeader = await getAuthorization()
+        expect(authHeader).toBeNull()
+    })
+})

--- a/frontend/tests/common/ConfirmationDialog.test.js
+++ b/frontend/tests/common/ConfirmationDialog.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ConfirmationDialog from '@/common/ConfirmationDialog.vue'
+
+// Basic stubbing for Vuetify components to avoid dragging in the whole library for unit tests
+const globalStubs = {
+    VDialog: {
+        template: '<div><slot /></div>',
+        props: ['modelValue']
+    },
+    VCard: { template: '<div><slot /></div>' },
+    VCardTitle: { template: '<div><slot /></div>' },
+    VCardActions: { template: '<div><slot /></div>' },
+    VSpacer: { template: '<div />' },
+    VBtn: {
+        template: '<button @click="$emit(\'click\')"><slot /></button>',
+        props: ['color', 'variant']
+    }
+}
+
+describe('ConfirmationDialog.vue', () => {
+    it('renders slot content', () => {
+        const wrapper = mount(ConfirmationDialog, {
+            props: {
+                active: true,
+            },
+            slots: {
+                default: 'Confirm this action?',
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        expect(wrapper.text()).toContain('Confirm this action?')
+    })
+
+    it('emits "canceled" and "done" when Cancel is clicked', async () => {
+        const wrapper = mount(ConfirmationDialog, {
+            props: {
+                active: true,
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const buttons = wrapper.findAll('button')
+        const cancelButton = buttons.find(b => b.text() === 'Cancel')
+
+        await cancelButton.trigger('click')
+
+        expect(wrapper.emitted('canceled')).toBeTruthy()
+        expect(wrapper.emitted('done')).toBeTruthy()
+        // It should also update the model value to false
+        expect(wrapper.emitted('update:active')[0]).toEqual([false])
+    })
+
+    it('emits "confirmed" and "done" when OK is clicked', async () => {
+        const wrapper = mount(ConfirmationDialog, {
+            props: {
+                active: true,
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const buttons = wrapper.findAll('button')
+        const okButton = buttons.find(b => b.text() === 'OK')
+
+        await okButton.trigger('click')
+
+        expect(wrapper.emitted('confirmed')).toBeTruthy()
+        expect(wrapper.emitted('done')).toBeTruthy()
+        expect(wrapper.emitted('update:active')[0]).toEqual([false])
+    })
+})

--- a/frontend/tests/common/Logger.test.js
+++ b/frontend/tests/common/Logger.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import logger from '@/common/Logger'
+import log from 'loglevel'
+
+// Mock loglevel
+vi.mock('loglevel', () => ({
+    default: {
+        setLevel: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}))
+
+describe('Logger', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should format message with timestamp and context', () => {
+        const message = 'Test message'
+        const context = { key: 'value' }
+        // We can't easily assert the exact timestamp, but we can check the structure
+        // Accessing internal method for testing logic if possible, or just checking the output passed to loglevel
+
+        logger.info(message, context)
+
+        expect(log.info).toHaveBeenCalledTimes(1)
+        const calledArg = log.info.mock.calls[0][0]
+        expect(calledArg).toContain(message)
+        expect(calledArg).toContain('{"key":"value"}')
+    })
+
+    it('should call log.debug for debug level', () => {
+        logger.debug('Debug msg')
+        expect(log.debug).toHaveBeenCalled()
+    })
+
+    it('should call log.info for info level', () => {
+        logger.info('Info msg')
+        expect(log.info).toHaveBeenCalled()
+    })
+
+    it('should call log.warn for warn level', () => {
+        logger.warn('Warn msg')
+        expect(log.warn).toHaveBeenCalled()
+    })
+
+    it('should call log.error for error level', () => {
+        logger.error('Error msg')
+        expect(log.error).toHaveBeenCalled()
+    })
+
+    it('should include error details in error log', () => {
+        const error = new Error('Something went wrong')
+        logger.error('Error msg', error)
+
+        expect(log.error).toHaveBeenCalled()
+        const calledArg = log.error.mock.calls[0][0]
+        expect(calledArg).toContain('Something went wrong') // Error message should be in context
+    })
+
+    it('apiSuccess should log info', () => {
+        logger.apiSuccess('fetchUsers', { count: 10 })
+        expect(log.info).toHaveBeenCalled()
+        const calledArg = log.info.mock.calls[0][0]
+        expect(calledArg).toContain('API Success: fetchUsers')
+    })
+
+    it('apiError should log error', () => {
+        const err = new Error('404 Not Found')
+        logger.apiError('fetchUsers', err)
+        expect(log.error).toHaveBeenCalled()
+        const calledArg = log.error.mock.calls[0][0]
+        expect(calledArg).toContain('API Error: fetchUsers')
+    })
+})

--- a/frontend/tests/common/MermaidDiagram.test.js
+++ b/frontend/tests/common/MermaidDiagram.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MermaidDiagram from '@/common/MermaidDiagram.vue'
+import mermaid from 'mermaid'
+
+// Mock mermaid module
+vi.mock('mermaid', () => ({
+    default: {
+        initialize: vi.fn(),
+        render: vi.fn()
+    }
+}))
+
+describe('MermaidDiagram.vue', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset render mock
+        mermaid.render.mockResolvedValue({ svg: '<svg>Mocked Diagram</svg>' })
+    })
+
+    it('renders placeholder when no definition is provided', () => {
+        const wrapper = mount(MermaidDiagram, {
+            props: {
+                definition: ''
+            }
+        })
+
+        expect(wrapper.find('.mermaid-placeholder').exists()).toBe(true)
+        expect(wrapper.text()).toContain('No diagram available')
+    })
+
+    it('initializes mermaid and renders diagram when definition is provided', async () => {
+        // We need to wait for the async watcher to fire and complete
+        const definition = 'graph TD; A-->B;'
+        const wrapper = mount(MermaidDiagram, {
+            props: {
+                definition
+            }
+        })
+
+        // Wait for promises to resolve (watch callback is async)
+        await new Promise(resolve => setTimeout(resolve, 10))
+        await wrapper.vm.$nextTick()
+
+        // Check initialization
+        expect(mermaid.initialize).toHaveBeenCalled()
+        expect(mermaid.initialize).toHaveBeenCalledWith(expect.objectContaining({
+            startOnLoad: false,
+            theme: 'neutral'
+        }))
+
+        // Check rendering
+        expect(mermaid.render).toHaveBeenCalled()
+        expect(mermaid.render).toHaveBeenCalledWith(
+            expect.stringMatching(/^mermaid-diagram-/),
+            definition
+        )
+
+        // Check output
+        expect(wrapper.find('.mermaid-diagram').exists()).toBe(true)
+        expect(wrapper.vm.svg).toBe('<svg>Mocked Diagram</svg>')
+    })
+
+    it('handles render errors gracefully', async () => {
+        // Mock console.error to prevent test output noise
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
+        mermaid.render.mockRejectedValue(new Error('Syntax error'))
+
+        const wrapper = mount(MermaidDiagram, {
+            props: {
+                definition: 'invalid graph'
+            }
+        })
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 10))
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.find('.mermaid-error').exists()).toBe(true)
+        expect(wrapper.text()).toContain('Syntax error')
+        expect(wrapper.find('.mermaid-diagram').exists()).toBe(false)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+    })
+
+    it('updates diagram when props change', async () => {
+        const wrapper = mount(MermaidDiagram, {
+            props: {
+                definition: 'graph A'
+            }
+        })
+
+        await new Promise(resolve => setTimeout(resolve, 10))
+        expect(mermaid.render).toHaveBeenCalledTimes(1)
+
+        // Change definition
+        await wrapper.setProps({ definition: 'graph B' })
+        await new Promise(resolve => setTimeout(resolve, 10))
+
+        expect(mermaid.render).toHaveBeenCalledTimes(2)
+        expect(mermaid.render.mock.calls[1][1]).toBe('graph B')
+    })
+})

--- a/frontend/tests/common/MultiLineTextEdit.test.js
+++ b/frontend/tests/common/MultiLineTextEdit.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MultiLineTextEdit from '@/common/MultiLineTextEdit.vue'
+
+// Stub VTextarea to mimic its v-model behavior
+// In Vuetify, v-textarea uses 'modelValue' prop and emits 'update:modelValue'
+const globalStubs = {
+    VTextarea: {
+        props: ['modelValue', 'label'],
+        template: `
+      <div class="v-textarea-stub">
+        <textarea 
+          :value="modelValue" 
+          @input="$emit('update:modelValue', $event.target.value)"
+        ></textarea>
+        <label>{{ label }}</label>
+      </div>
+    `
+    }
+}
+
+describe('MultiLineTextEdit.vue', () => {
+    it('renders correctly with label', () => {
+        const wrapper = mount(MultiLineTextEdit, {
+            props: {
+                label: 'My Label',
+                modelValue: 'Initial text'
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        expect(wrapper.find('label').text()).toBe('My Label')
+        expect(wrapper.find('textarea').element.value).toBe('Initial text')
+    })
+
+    it('emits update:modelValue when input changes', async () => {
+        const wrapper = mount(MultiLineTextEdit, {
+            props: {
+                modelValue: ''
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const textarea = wrapper.find('textarea')
+        await textarea.setValue('New text')
+
+        expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+        expect(wrapper.emitted('update:modelValue')[0]).toEqual(['New text'])
+    })
+})

--- a/frontend/tests/conversational/SystemMessageComponent.test.js
+++ b/frontend/tests/conversational/SystemMessageComponent.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SystemMessageComponent from '@/conversational/SystemMessageComponent.vue'
+
+// Define a stub for v-container since it's a Vuetify component
+const globalStubs = {
+    VContainer: {
+        template: '<div><slot /></div>'
+    }
+}
+
+describe('SystemMessageComponent.vue', () => {
+    it('renders markdown content correctly', () => {
+        const message = '**Hello** world'
+        const wrapper = mount(SystemMessageComponent, {
+            props: {
+                message
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const bubble = wrapper.find('.system-bubble')
+        expect(bubble.exists()).toBe(true)
+        // marked should convert **Hello** to <strong>Hello</strong> or <b>Hello</b> depending on version/config, 
+        // but usually it's strong.
+        expect(bubble.element.innerHTML).toContain('<strong>Hello</strong>')
+        expect(bubble.text()).toContain('Hello world')
+    })
+
+    it('handles empty message safely', () => {
+        const wrapper = mount(SystemMessageComponent, {
+            props: {
+                message: null
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const bubble = wrapper.find('.system-bubble')
+        expect(bubble.exists()).toBe(true)
+        expect(bubble.text()).toBe('')
+    })
+})

--- a/frontend/tests/conversational/UserMessageComponent.test.js
+++ b/frontend/tests/conversational/UserMessageComponent.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import UserMessageComponent from '@/conversational/UserMessageComponent.vue'
+
+const globalStubs = {
+    VContainer: {
+        template: '<div><slot /></div>'
+    }
+}
+
+describe('UserMessageComponent.vue', () => {
+    it('renders markdown content correctly', () => {
+        const message = '*Italic* text'
+        const wrapper = mount(UserMessageComponent, {
+            props: {
+                message
+            },
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const bubble = wrapper.find('.user-bubble')
+        expect(bubble.exists()).toBe(true)
+        expect(bubble.element.innerHTML).toContain('<em>Italic</em>')
+        expect(bubble.text()).toContain('Italic text')
+    })
+
+    it('handles undefined message safely', () => {
+        const wrapper = mount(UserMessageComponent, {
+            global: {
+                stubs: globalStubs
+            }
+        })
+
+        const bubble = wrapper.find('.user-bubble')
+        expect(bubble.exists()).toBe(true)
+        expect(bubble.text()).toBe('')
+    })
+})

--- a/frontend/tests/doc-mgr/AddDocSetDialog.test.js
+++ b/frontend/tests/doc-mgr/AddDocSetDialog.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AddDocSetDialog from '@/doc-mgr/AddDocSetDialog.vue'
+
+const globalStubs = {
+    VDialog: { template: '<div><slot /></div>', props: ['modelValue'] },
+    VCard: { template: '<div><slot /></div>' },
+    VCardTitle: { template: '<div><slot /></div>' },
+    VCardText: { template: '<div><slot /></div>' },
+    VCardActions: { template: '<div><slot /></div>' },
+    VSpacer: { template: '<div />' },
+    VBtn: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+    VTextField: {
+        template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        props: ['modelValue', 'label']
+    },
+    VSelect: {
+        template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"></select>',
+        props: ['modelValue', 'items', 'label']
+    },
+    VCheckbox: {
+        template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+        props: ['modelValue', 'label']
+    }
+}
+
+describe('AddDocSetDialog.vue', () => {
+    it('renders correctly with default values', () => {
+        const wrapper = mount(AddDocSetDialog, {
+            props: {
+                active: true
+            },
+            global: { stubs: globalStubs }
+        })
+
+        expect(wrapper.text()).toContain('New Document Set')
+
+        // Check default values if inputs are connected
+        // checkbox for isPublicViewable defaults to true
+        // checkbox for isNewDocDefault defaults to false
+    })
+
+    it('emits confirmed event with data', async () => {
+        const wrapper = mount(AddDocSetDialog, {
+            props: {
+                active: true
+            },
+            global: { stubs: globalStubs }
+        })
+
+        // Simulate user input
+        const inputs = wrapper.findAll('input')
+        // Assumes order: text-field (name), checkbox (public), checkbox (default)
+        await inputs[0].setValue('New Set')
+
+        const okBtn = wrapper.findAll('button').find(b => b.text() === 'OK')
+        await okBtn.trigger('click')
+
+        expect(wrapper.emitted('confirmed')).toBeTruthy()
+        expect(wrapper.emitted('update:active')[0]).toEqual([false])
+
+        // Check model update
+        expect(wrapper.props('modelValue').name).toBe('New Set')
+    })
+})

--- a/frontend/tests/doc-mgr/DocumentTableComponent.test.js
+++ b/frontend/tests/doc-mgr/DocumentTableComponent.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import DocumentTableComponent from '@/doc-mgr/DocumentTableComponent.vue'
+import { useDocumentStore } from '@/doc-mgr/DocStore'
+
+// Mock CommonDataTable and other components to avoid rendering full children
+const globalStubs = {
+    CommonDataTable: {
+        name: 'CommonDataTable',
+        template: `
+      <div>
+        <slot name="more-action-icons" :item="{ id: '1', name: 'Doc 1' }" :index="0"></slot>
+        <slot name="more-selected-items-buttons" :selectedItemCount="1"></slot>
+        <slot name="more-action-dialogs" :selectedItemCount="1"></slot>
+      </div>
+    `,
+        props: ['deleteSingleItem', 'deleteMultipleItems', 'loadItems', 'loadTableStats']
+    },
+    ConfirmationDialog: {
+        template: '<div class="confirmation-dialog-stub" @click="$emit(\'confirmed\')"></div>',
+        props: ['active']
+    },
+    EditDocDialog: {
+        template: '<div class="edit-doc-dialog-stub" @click="$emit(\'confirmed\')"></div>',
+        props: ['active', 'modelValue']
+    },
+    VIcon: { template: '<span class="v-icon-stub" @click="$emit(\'click\')"><slot /></span>' },
+    VBtn: { template: '<button class="v-btn-stub" @click="$emit(\'click\')"><slot /></button>' }
+}
+
+// Mock AuthUtils
+vi.mock('@/common/AuthUtils.js', () => ({
+    getAuthorization: vi.fn().mockResolvedValue('Bearer token')
+}))
+
+// Mock Logger
+vi.mock('@/common/Logger.js', () => ({
+    default: {
+        apiSuccess: vi.fn(),
+        apiError: vi.fn()
+    }
+}))
+
+// Mock Fetch
+global.fetch = vi.fn(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({})
+}))
+
+describe('DocumentTableComponent.vue', () => {
+    let wrapper
+    let store
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+
+        wrapper = mount(DocumentTableComponent, {
+            global: {
+                plugins: [
+                    createTestingPinia({
+                        createSpy: vi.fn,
+                        initialState: {
+                            documentStore: {
+                                page: 1,
+                                itemsPerPage: 10,
+                                totalItems: 0,
+                                items: [],
+                                selectedItems: [],
+                                documentSetFilter: null,
+                                contentTypeFilter: null,
+                                sourceUrlFilter: null
+                            }
+                        }
+                    })
+                ],
+                stubs: globalStubs
+            }
+        })
+        store = useDocumentStore()
+    })
+
+    it('renders CommonDataTable', () => {
+        expect(wrapper.findComponent({ name: 'CommonDataTable' }).exists()).toBe(true)
+    })
+
+    it('calls ingest API when ingest single item is confirmed', async () => {
+        // 1. Trigger ingest icon click (in slot)
+        const ingestIcon = wrapper.findAll('.v-icon-stub').find(icon => icon.text() === 'mdi-database-import')
+        await ingestIcon.trigger('click')
+
+        // 2. Expect confirmation dialog to be active (checking logic, triggering confirm)
+        // In our stub, clicking the dialog emits 'confirmed'
+        const confirmDialog = wrapper.find('.confirmation-dialog-stub')
+        await confirmDialog.trigger('click')
+
+        // 3. Verify fetch called
+        expect(global.fetch).toHaveBeenCalledWith('/api/documents/ingest', expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ docUuids: ['1'] }, null, 2)
+        }))
+    })
+
+    it('calls ingest all uploaded API when button clicked', async () => {
+        const ingestAllButton = wrapper.findAll('button').find(b => b.text() === 'Ingest All Uploaded')
+        await ingestAllButton.trigger('click')
+
+        // Find the SECOND confirmation dialog (index based on template order)
+        // 1. Ingest Item, 2. Ingest All Uploaded, 3. Ingest Selected
+        const confirmDialogs = wrapper.findAll('.confirmation-dialog-stub')
+        await confirmDialogs[1].trigger('click')
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/documents/ingest', expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ allUploaded: true }, null, 2)
+        }))
+    })
+
+    it('calls ingest selected API when button clicked', async () => {
+        // Set selected items in store or via v-model if 2-way binding works with stub
+        store.selectedItems = [{ id: '100', name: 'Selected Doc' }]
+
+        const ingestSelectedButton = wrapper.findAll('button').find(b => b.text() === 'Ingest Selected')
+        await ingestSelectedButton.trigger('click')
+
+        // 3rd dialog
+        const confirmDialogs = wrapper.findAll('.confirmation-dialog-stub')
+        await confirmDialogs[2].trigger('click')
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/documents/ingest', expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ docUuids: ['100'] }, null, 2)
+        }))
+    })
+
+})

--- a/frontend/tests/doc-mgr/EditDocDialog.test.js
+++ b/frontend/tests/doc-mgr/EditDocDialog.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EditDocDialog from '@/doc-mgr/EditDocDialog.vue'
+
+const globalStubs = {
+    VDialog: { template: '<div><slot /></div>', props: ['modelValue'] },
+    VCard: { template: '<div><slot /></div>' },
+    VCardTitle: { template: '<div><slot /></div>' },
+    VCardText: { template: '<div><slot /></div>' },
+    VCardActions: { template: '<div><slot /></div>' },
+    VSpacer: { template: '<div />' },
+    VBtn: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+    VTextField: {
+        template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        props: ['modelValue', 'label']
+    },
+    VSelect: {
+        template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"></select>',
+        props: ['modelValue', 'items', 'label']
+    }
+}
+
+describe('EditDocDialog.vue', () => {
+    const defaultModelValue = {
+        name: 'Test Doc',
+        documentSetName: 'Set A',
+        ocrStrategy: 'fast'
+    }
+
+    it('renders correctly with model data', () => {
+        const wrapper = mount(EditDocDialog, {
+            props: {
+                active: true,
+                modelValue: defaultModelValue
+            },
+            global: { stubs: globalStubs }
+        })
+
+        const inputs = wrapper.findAll('input')
+        expect(inputs[0].element.value).toBe('Test Doc')
+        expect(inputs[1].element.value).toBe('Set A')
+    })
+
+    it('emits confirmed event when OK is clicked', async () => {
+        const wrapper = mount(EditDocDialog, {
+            props: {
+                active: true,
+                modelValue: defaultModelValue
+            },
+            global: { stubs: globalStubs }
+        })
+
+        const okBtn = wrapper.findAll('button').find(b => b.text() === 'OK')
+        await okBtn.trigger('click')
+
+        expect(wrapper.emitted('confirmed')).toBeTruthy()
+        expect(wrapper.emitted('update:active')[0]).toEqual([false])
+    })
+
+    it('emits canceled event when Cancel is clicked', async () => {
+        const wrapper = mount(EditDocDialog, {
+            props: {
+                active: true,
+                modelValue: defaultModelValue
+            },
+            global: { stubs: globalStubs }
+        })
+
+        const cancelBtn = wrapper.findAll('button').find(b => b.text() === 'Cancel')
+        await cancelBtn.trigger('click')
+
+        expect(wrapper.emitted('canceled')).toBeTruthy()
+        expect(wrapper.emitted('update:active')[0]).toEqual([false])
+    })
+})

--- a/frontend/tests/prompt-mgr/PromptManagerView.test.js
+++ b/frontend/tests/prompt-mgr/PromptManagerView.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PromptManagerView from '@/prompt-mgr/PromptManagerView.vue'
+
+// Mock vue-router
+const pushMock = vi.fn()
+vi.mock('vue-router', () => ({
+    useRouter: () => ({
+        push: pushMock
+    })
+}))
+
+// Stubs for Vuetify and RouterView
+const globalStubs = {
+    VTabs: { template: '<div><slot /></div>', props: ['modelValue', 'bgColor'] },
+    VTab: { template: '<button @click="$emit(\'click\')"><slot /></button>', props: ['value', 'to'] },
+    RouterView: { template: '<div class="router-view-stub"></div>' }
+}
+
+describe('PromptManagerView.vue', () => {
+    it('renders title and tabs', () => {
+        const wrapper = mount(PromptManagerView, {
+            global: { stubs: globalStubs }
+        })
+
+        expect(wrapper.find('h2').text()).toBe('Prompt Manager')
+        expect(wrapper.findAll('button').length).toBe(2)
+    })
+
+    it('renders router-view', () => {
+        const wrapper = mount(PromptManagerView, {
+            global: { stubs: globalStubs }
+        })
+
+        expect(wrapper.find('.router-view-stub').exists()).toBe(true)
+    })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
             'webui-server-autotest'
         ],
     },
+    test: {
+        environment: 'jsdom',
+    },
     plugins: [
         vue({
             template: {

--- a/services/api-server/build/Dockerfile
+++ b/services/api-server/build/Dockerfile
@@ -94,6 +94,7 @@ COPY --from=config-dir ./run_api_server.sh /run_api_server.sh
 COPY --from=config-dir ./supervisord.conf /etc/supervisord.conf
 
 COPY --from=config-dir ./mount_helper.sh /usr/local/bin/mount_helper.sh
+COPY --from=config-dir ./stop_supervisor.sh /stop_supervisor.sh
 
 COPY --from=celery-config-dir ./run_celery_worker.sh /run_celery_worker.sh
 COPY --from=celery-config-dir ./run_celery_flower.sh /run_celery_flower.sh

--- a/services/api-server/build/cuda12.Dockerfile
+++ b/services/api-server/build/cuda12.Dockerfile
@@ -185,6 +185,7 @@ COPY --from=config-dir ./run_api_server.sh /run_api_server.sh
 COPY --from=config-dir ./supervisord.conf /etc/supervisord.conf
 
 COPY --from=config-dir ./mount_helper.sh /usr/local/bin/mount_helper.sh
+COPY --from=config-dir ./stop_supervisor.sh /stop_supervisor.sh
 
 COPY --from=celery-config-dir ./run_celery_worker.sh /
 COPY --from=celery-config-dir ./run_celery_flower.sh /

--- a/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -7,8 +7,8 @@ cd /app/backend
 
 if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
 
-    echo "Waiting for mount at /app/backend..."
-
+    echo "USE_FUSE_SRC_DIR is set to true. Waiting for mount at /app/backend..."
+    
     # Wait for mount
     attempt=0
     while ! mountpoint -q /app/backend; do
@@ -22,32 +22,28 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
 
     echo "Mount active."
 
-    echo "Waiting for mount at /app/backend/.venv..."
-
     # Wait for mount
     attempt=0
     while ! mountpoint -q /app/backend/.venv; do
         sleep 1
         attempt=$((attempt+1))
         if [ $attempt -ge 30 ]; then
-            echo "Error: Mount failed to appear after 30 seconds."
+            echo "Error: .venv mount failed to appear after 30 seconds."
             exit 1
         fi
     done
+fi
 
-    echo "Mount active."
+# Change directory. If we are mount file-systems, then this operation must
+# wait until after the mounts are ready.
+#
+cd /app/backend
 
 
-    #    
-    # Create the virtual environment only once.
-    #
-    # For the CACHEDIR.TAG specification, see https://bford.info/cachedir/
-    # For uv's explanation, see: https://github.com/astral-sh/uv/issues/1648
-    if [ ! -f ".venv/CACHEDIR.TAG" ] \
-        || ! ( grep -q "Signature: 8a477f597d28d172789f06886806bc55" ".venv/CACHEDIR.TAG" )
-    then
-        uv venv --allow-existing
-    fi
+if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
+
+    # Create or ensure the virtual environment exists.
+    uv venv --allow-existing
 
     # Sync the virtual environment (persistent across restarts now)
     # Use --frozen to prevent writing to the lockfile (which might be read-only or owned by another user)
@@ -77,6 +73,19 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
         exit $EXIT_CODE
     fi
 fi
+
+# Wait for valid virtual environment
+attempt=0
+while [ ! -f ".venv/bin/activate" ]; do
+    echo "Waiting for .venv/bin/activate..."
+    sleep 1
+    attempt=$((attempt+1))
+    if [ $attempt -ge 10 ]; then
+         echo "Error: .venv/bin/activate not found after 10 seconds."
+         ls -la .venv || true
+         exit 1
+    fi
+done
 
 source .venv/bin/activate
 

--- a/services/api-server/config/custom-docker-entrypoint.sh
+++ b/services/api-server/config/custom-docker-entrypoint.sh
@@ -46,6 +46,7 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     # We rely on /etc/supervisord.conf
     # Pass the command arguments to supervisor via environment variable
     export APP_COMMAND="$*"
+    export APP_AUTORESTART="${APP_AUTORESTART:-true}"
     exec /usr/bin/supervisord -c /etc/supervisord.conf
 else
     # Legacy/Standard flow (NFS or copy)

--- a/services/api-server/config/mount_helper.sh
+++ b/services/api-server/config/mount_helper.sh
@@ -34,6 +34,7 @@ if [ -d "/home/python/.venv-storage" ]; then
      # Check if already mounted (in case of restart)
      if ! mountpoint -q /app/backend/.venv; then
         mount --bind /home/python/.venv-storage /app/backend/.venv || echo "$ECHO_PREFIX Warning: Failed to mount .venv"
+        echo "$ECHO_PREFIX .venv mounted."
      else
         echo "$ECHO_PREFIX .venv already mounted."
      fi

--- a/services/api-server/config/run_automated_test.sh
+++ b/services/api-server/config/run_automated_test.sh
@@ -77,17 +77,14 @@ if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
     WATCH_DEBOUNCE_SECS=20.0
 fi
 
-df -h
-ls ./libs
-cat ./libs/core_db/tests/conftest.py
+#   -- \
+#   watchmedo auto-restart \
+#   --debug-force-polling \
+#   --no-restart-on-command-exit \
+#   --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
+#   --directory=./apps --directory=./libs  --recursive --pattern='*.py' \
 
 uv run --frozen --no-sync \
-   -- \
-   watchmedo auto-restart \
-   --debug-force-polling \
-   --no-restart-on-command-exit \
-   --debounce-interval="${WATCH_DEBOUNCE_SECS}" \
-   --directory=./apps --directory=./libs  --recursive --pattern='*.py' \
    -- \
    pytest -v -v --capture=tee-sys apps libs
 

--- a/services/api-server/config/stop_supervisor.sh
+++ b/services/api-server/config/stop_supervisor.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script is a Supervisor event listener.
+# It listens for PROCESS_STATE_EXITED events.
+# If the process name matches "app", it sends SIGTERM to supervisord.
+
+while true; do
+    # Signal readiness
+    printf "READY\n"
+
+    # Read the header line
+    if ! read -r line; then
+        break
+    fi
+
+    # Parse length from header
+    # Header format: ver:3.0 server:supervisor ... len:84
+    len=$(echo "$line" | sed -n 's/.*len:\([0-9]*\).*/\1/p')
+
+    # Read the payload
+    if [ -n "$len" ]; then
+        if ! read -r -N "$len" payload; then
+            break
+        fi
+    fi
+
+    # Check for PROCESS_STATE_EXITED and processname:app
+    if [[ "$line" == *"eventname:PROCESS_STATE_EXITED"* ]]; then
+        # We check if the processname in the payload is "app"
+        if [[ "$payload" == *"processname:app"* ]]; then
+             # Kill supervisor using the pid file.
+             # This assumes supervisord runs as root or the same user.
+             if [ -f /var/run/supervisord.pid ]; then
+                 kill -SIGTERM $(cat /var/run/supervisord.pid)
+             else
+                 # Fallback if pidfile missing (unlikely if configured)
+                 pkill -SIGTERM supervisord
+             fi
+        fi
+    fi
+
+    # Acknowledge the event
+    printf "RESULT 2\nOK"
+done

--- a/services/api-server/config/supervisord.conf
+++ b/services/api-server/config/supervisord.conf
@@ -45,7 +45,7 @@ user=python
 # Explicitly set HOME.
 environment=HOME="/home/python"
 autostart=true
-autorestart=true
+autorestart=%(ENV_APP_AUTORESTART)s
 ; This ensures app doesn't start until mount-helper finishes (conceptually).
 ; Supervisor doesn't support 'depends_on' natively in standard version. 
 ; We'll use a wrapper in run_api_server.sh or rely on mount_helper to block? 
@@ -60,3 +60,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[eventlistener:stop-on-app-exit]
+command=/stop_supervisor.sh
+events=PROCESS_STATE_EXITED

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -137,8 +137,9 @@ services:
       ##
       ##
       # Mount the FUSE directory into this container
-      USE_FUSE_SRC_DIR: true
+      USE_FUSE_SRC_DIR: 'true'
       PYTHONPYCACHEPREFIX: /home/python/.pycache
+      APP_AUTORESTART: 'false'
     cap_add:
       - SYS_ADMIN
     devices:
@@ -156,9 +157,11 @@ services:
       # avoiding rebuilding images to capture their latest version.
       - ../config/run_automated_test.sh:/run_automated_test.sh:ro
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
+      - ../config/mount_helper.sh:/usr/local/bin/mount_helper.sh:ro
       - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
-      - ../config/supervisord.conf:/etc/supervisord.conf:ro
       - ../config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
+      - ../config/supervisord.conf:/etc/supervisord.conf:ro
+      - ../config/stop_supervisor.sh:/stop_supervisor.sh:ro
       ##SRC - backend-autotest-home-4:/home/python
       ##SRC - backend-autotest-venv-4:/app/backend/.venv
     secrets:

--- a/services/webui-server/build/Dockerfile
+++ b/services/webui-server/build/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=config-dir ./custom-docker-entrypoint-nonpriv.sh /custom-docker-entr
 COPY --from=config-dir ./run_webui_server.sh /run_webui_server.sh
 COPY --from=config-dir ./supervisord.conf /etc/supervisord.conf
 COPY --from=config-dir ./webui_mount_helper.sh /usr/local/bin/webui_mount_helper.sh
+COPY --from=config-dir ./stop_supervisor.sh /stop_supervisor.sh
 
 COPY --from=dependency-gate-dir ./wait_for_resource.sh /
 
@@ -72,6 +73,11 @@ CMD ["run_webui_server.sh"]
 # Switch to the custom user
 USER ${USER_ID}:${GROUP_ID}
 
+#================
+#
+# production
+#
+
 FROM production-base AS production
 
 ARG USER_ID=1000
@@ -88,6 +94,10 @@ RUN \
 # Switch to the custom user
 USER ${USER_ID}:${GROUP_ID}
 
+#================
+#
+# dev
+#
 
 FROM production-base AS dev
 
@@ -126,6 +136,89 @@ ENTRYPOINT [ "bash", "/custom-docker-entrypoint.sh" ]
 
 # Build the app then start the Vue.js development server
 CMD ["run_webui_server.sh"]
+
+# Switch to the custom user
+USER ${USER_ID}:${GROUP_ID}
+
+#================
+#
+# test / playwright
+#
+
+FROM production-base AS test-xvfb
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+USER root
+
+# This is to allow the container user to mount the directory using FUSE.
+# The user will run the 'weed mount' command.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    fuse3 \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    # Install weed CLI
+    && curl -L https://github.com/seaweedfs/seaweedfs/releases/download/3.79/linux_amd64.tar.gz | tar xz -C /usr/local/bin weed
+
+RUN \
+    export DEBIAN_FRONTEND=noninteractive ; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    bind9-dnsutils \
+    iproute2 \
+    psmisc \
+    tree \
+    openssh-client \
+    patch \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install system dependencies and browsers
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    xauth \
+    xvfb \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    chromium \
+    firefox-esr \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=config-dir ./run_automated_tests.sh /run_automated_tests.sh
+COPY --from=config-dir ./webui_mount_helper.sh /usr/local/bin/webui_mount_helper.sh
+
+COPY --from=dependency-gate-dir ./wait_for_resource.sh /
+
+
+
+RUN chmod a+x /custom-docker-entrypoint.sh \
+    && chmod a+x /custom-docker-entrypoint-nonpriv.sh \
+    && chmod a+x /run_automated_tests.sh \
+    && chmod a+x /usr/local/bin/webui_mount_helper.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint.sh \
+    && chown ${USER_ID}:${GROUP_ID} /custom-docker-entrypoint-nonpriv.sh \
+    && chown ${USER_ID}:${GROUP_ID} /run_automated_tests.sh
+
+
+ENTRYPOINT [ "bash", "/custom-docker-entrypoint.sh" ]
+
+# Build the app then start the Vue.js development server
+CMD ["run_automated_tests.sh"]
 
 # Switch to the custom user
 USER ${USER_ID}:${GROUP_ID}

--- a/services/webui-server/build/build_images.sh
+++ b/services/webui-server/build/build_images.sh
@@ -46,3 +46,15 @@ $DOCKER build \
   --progress plain \
   . 2>&1 \
 | tee $LOG_DIR/build-frontend-dev.log
+
+$DOCKER build \
+  $DOCKER_BUILD_OPTS \
+  --file Dockerfile \
+  --build-context config-dir=../config/ \
+  --build-context dependency-gate-dir=../../dependency-gate \
+  --build-context frontend-dir=../../../frontend/ \
+  --target test-xvfb \
+  --tag localhost/localhost/answers-frontend-test-xvfb:node-22-bookworm \
+  --progress plain \
+  . 2>&1 \
+| tee $LOG_DIR/build-frontend-test-xvfb.log

--- a/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -42,7 +42,7 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
         fi
     done
 
-    echo "Mount active."
+    echo "Mount node_modules active."
 fi
 
 # Transition to the non-privileged entrypoint

--- a/services/webui-server/config/custom-docker-entrypoint.sh
+++ b/services/webui-server/config/custom-docker-entrypoint.sh
@@ -12,6 +12,7 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     mkdir -p /app/frontend
     
     export APP_COMMAND="$*"
+    export APP_AUTORESTART="${APP_AUTORESTART:-true}"
     exec /usr/bin/supervisord -c /etc/supervisord.conf
 else
     # Standard Mode

--- a/services/webui-server/config/run_automated_tests.sh
+++ b/services/webui-server/config/run_automated_tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately on error.
+set -u  # Unbound variables are errors.
+set -o pipefail  # Use right-most non-zero exit code from a pipe.
+
+# Set environment variables from mounted secrets files
+
+SECRETS_MOUNT="${SECRETS_MOUNT:-/run/secrets}"
+# shellcheck disable=SC2046
+export $( grep -h -v "^#" "${SECRETS_MOUNT}"/*_secrets | xargs -n1 )
+
+
+if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
+    # Install dependencies
+    # Determine install command based on whether node_modules is a mount point
+    # npm ci tries to remove the node_modules directory which fails on mount points.
+    NPM_CMD="npm install"
+    if grep -q " /app/frontend/node_modules " /proc/mounts; then
+        echo "node_modules is a bind mount. Using npm install."
+        NPM_CMD="npm install"
+    fi
+
+    set +e
+    $NPM_CMD
+    EXIT_CODE=$?
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Error: $NPM_CMD failed. Attempting to recover by cleaning cache..."
+        npm cache clean --force
+        $NPM_CMD
+        EXIT_CODE=$?
+    fi
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Error: npm ci failed again after cache clean."
+        echo "This is likely because package-lock.json is not up-to-date with package.json."
+        echo "Please run 'npm install' on your host machine to update package-lock.json."
+        exit $EXIT_CODE
+    fi
+fi
+
+npm run test:unit

--- a/services/webui-server/config/stop_supervisor.sh
+++ b/services/webui-server/config/stop_supervisor.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script is a Supervisor event listener.
+# It listens for PROCESS_STATE_EXITED events.
+# If the process name matches "app", it sends SIGTERM to supervisord.
+
+while true; do
+    # Signal readiness
+    printf "READY\n"
+
+    # Read the header line
+    if ! read -r line; then
+        break
+    fi
+
+    # Parse length from header
+    # Header format: ver:3.0 server:supervisor ... len:84
+    len=$(echo "$line" | sed -n 's/.*len:\([0-9]*\).*/\1/p')
+
+    # Read the payload
+    if [ -n "$len" ]; then
+        if ! read -r -N "$len" payload; then
+            break
+        fi
+    fi
+
+    # Check for PROCESS_STATE_EXITED and processname:app
+    if [[ "$line" == *"eventname:PROCESS_STATE_EXITED"* ]]; then
+        # We check if the processname in the payload is "app"
+        if [[ "$payload" == *"processname:app"* ]]; then
+             # Kill supervisor using the pid file.
+             # This assumes supervisord runs as root or the same user.
+             if [ -f /var/run/supervisord.pid ]; then
+                 kill -SIGTERM $(cat /var/run/supervisord.pid)
+             else
+                 # Fallback if pidfile missing (unlikely if configured)
+                 pkill -SIGTERM supervisord
+             fi
+        fi
+    fi
+
+    # Acknowledge the event
+    printf "RESULT 2\nOK"
+done

--- a/services/webui-server/config/supervisord.conf
+++ b/services/webui-server/config/supervisord.conf
@@ -33,8 +33,12 @@ command=/custom-docker-entrypoint-nonpriv.sh %(ENV_APP_COMMAND)s
 user=node
 environment=HOME="/home/node",USER="node"
 autostart=true
-autorestart=true
+autorestart=%(ENV_APP_AUTORESTART)s
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[eventlistener:stop-on-app-exit]
+command=/stop_supervisor.sh
+events=PROCESS_STATE_EXITED

--- a/services/webui-server/deploy/compose-autotest.yml
+++ b/services/webui-server/deploy/compose-autotest.yml
@@ -46,3 +46,53 @@ services:
     entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
     command: [ '/run_webui_server.sh' ]
     user: root
+
+  automated-vitest:
+    image: 'localhost/localhost/answers-frontend-test-xvfb:node-22-bookworm'
+    profiles: [ frontend-autotest, all ]
+    privileged: true
+
+    environment:
+      # Only environment variables that are important to the Docker environment
+      # will be configured here. All other environment variables are extracted
+      # to .env files for easier and more isolated management.
+      CHOKIDAR_USEPOLLING: 'true'
+      # Mount the FUSE directory into this container
+      USE_FUSE_SRC_DIR: true
+      # Codebase bucket credentials
+      CODEBASE_ACCESS_KEY:
+      SEAWEEDFS_FILER: 'seaweedfs:9002'
+      S3_ENDPOINT_URL: 'http://seaweedfs:9000'
+      WEED_MOUNT_EXTRA_ARGS: ''
+      APP_AUTORESTART: 'false'
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    security_opt:
+      - apparmor:unconfined
+    #   - NODE_ENV=production
+    ## Do not expose 5173 ... To prevent XSS (cross site scripting) usage, we want all
+    ## traffic to go thru the reserve-proxy server at 15173.
+    # ports:
+    #   - '5173:5173'
+    networks:
+      - agent-poc
+    volumes:
+      - ../config/run_automated_tests.sh:/run_automated_tests.sh:ro
+      - ../config/custom-docker-entrypoint-nonpriv.sh:/custom-docker-entrypoint-nonpriv.sh:ro
+      ##SRC - ../../dependency-gate/wait_for_resource.sh:/wait_for_resource.sh:ro
+      - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
+      - ../config/supervisord.conf:/etc/supervisord.conf:ro
+      - ../config/stop_supervisor.sh:/stop_supervisor.sh:ro
+      # Mount important script into the container when we are
+      # avoiding rebuilding images to capture their latest version.
+      ##SRC - ../build/run_webui_server.sh:/run_webui_server.sh:ro
+      
+
+    secrets:
+      - codebase_seaweedfs_secrets
+
+    entrypoint: [ 'bash', '/custom-docker-entrypoint.sh' ]
+    command: [ '/run_automated_tests.sh' ]
+    user: root


### PR DESCRIPTION
This PR gets automated tests written in vitest and pytest working as run-and-exit jobs.

The automated frontend tests are new. The automated backend tests existed previously inside a long-running file-system watching system. The run-and-exit style will be easier to manage because it can hook into different initiators and the debouncing (to remove false starts during periods of high system activity) can be smarter.