### PR TITLE
faster docker builds

### DIFF
--- a/services/api-server/build/.dockerignore
+++ b/services/api-server/build/.dockerignore
@@ -4,4 +4,20 @@ build_images.sh
 Dockerfile
 *.Dockerfile
 
+logs
 *.log
+
+
+.git
+
+**/__pycache__/
+**/*.egg-info/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/
+**/.ruff_cache/
+**/.venv/
+
+backend/**/dist/
+
+**/node_modules/

--- a/services/api-server/build/build_images.sh
+++ b/services/api-server/build/build_images.sh
@@ -18,12 +18,36 @@ DOCKER="docker buildx"
 #DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
 LOG_DIR=../../../logs
+CACHE_DIR=../../../.buildkit-cache
+
+#
+# Setup optimized BuildKit builder with GC
+#
+BUILDER_NAME="answers-optimized-builder"
+if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+    echo "Creating optimized builder: $BUILDER_NAME"
+    docker buildx create --name "$BUILDER_NAME" \
+        --driver docker-container \
+        --driver-opt default-load=true \
+        --buildkitd-flags '--oci-worker-gc=true --oci-worker-gc-keepstorage=50000000000' \
+        --bootstrap
+fi
+
+# Use the optimized builder
+docker buildx use "$BUILDER_NAME"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$CACHE_DIR"
+
+# Cache configuration for all builds
+CACHE_OPTS="--cache-from type=local,src=$CACHE_DIR --cache-to type=local,dest=$CACHE_DIR,mode=max"
 
 #
 # Build an image with Python 3.12 on Debian 12
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --target python3.12-cpu \
   --tag localhost/localhost/python:3.12.10-bookworm-cpu \
@@ -36,6 +60,7 @@ $DOCKER build \
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file cuda12.Dockerfile \
   --target python3.12-cuda12-cudnn9 \
   --tag localhost/localhost/python:3.12.10-bookworm-cuda12-cudnn9 \
@@ -48,6 +73,7 @@ $DOCKER build \
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config \
   --build-context celery-config-dir=../../celery-worker/config \
@@ -61,6 +87,7 @@ $DOCKER build \
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config \
   --build-context celery-config-dir=../../celery-worker/config \
@@ -78,6 +105,7 @@ $DOCKER build \
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file cuda12.Dockerfile \
   --build-context config-dir=../config \
   --build-context celery-config-dir=../../celery-worker/config \
@@ -91,6 +119,7 @@ $DOCKER build \
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file cuda12.Dockerfile \
   --build-context config-dir=../config \
   --build-context celery-config-dir=../../celery-worker/config \
@@ -101,3 +130,9 @@ $DOCKER build \
   --progress plain \
   . 2>&1 \
 | tee $LOG_DIR/build-backend-dev-python-cuda12.log
+
+#
+# Clean up old cache (keep last 50GB)
+#
+echo "Pruning old build cache..."
+docker buildx prune --builder "$BUILDER_NAME" --keep-storage 50GB --force

--- a/services/dev-server/build/build_images.sh
+++ b/services/dev-server/build/build_images.sh
@@ -19,14 +19,38 @@ DOCKER="docker buildx"
 #DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
 LOG_DIR=../../../logs
+CACHE_DIR=../../../.buildkit-cache
 
 mkdir -p $LOG_DIR
+
+#
+# Setup optimized BuildKit builder with GC
+#
+BUILDER_NAME="answers-optimized-builder"
+if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+    echo "Creating optimized builder: $BUILDER_NAME"
+    docker buildx create --name "$BUILDER_NAME" \
+        --driver docker-container \
+        --driver-opt default-load=true \
+        --buildkitd-flags '--oci-worker-gc=true --oci-worker-gc-keepstorage=50000000000' \
+        --bootstrap
+fi
+
+# Use the optimized builder
+docker buildx use "$BUILDER_NAME"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$CACHE_DIR"
+
+# Cache configuration for all builds
+CACHE_OPTS="--cache-from type=local,src=$CACHE_DIR --cache-to type=local,dest=$CACHE_DIR,mode=max"
 
 #
 # Build a dev-server image with Python 3.12 on Debian 12 (CPU only)
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config \
   --target dev \
@@ -40,6 +64,7 @@ $DOCKER build \
 #
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file cuda12.Dockerfile \
   --build-context config-dir=../config \
   --target dev \
@@ -47,3 +72,9 @@ $DOCKER build \
   --progress plain \
   . 2>&1 \
 | tee $LOG_DIR/build-dev-server-python-cuda12.log
+
+#
+# Clean up old cache (keep last 50GB)
+#
+echo "Pruning old build cache..."
+docker buildx prune --builder "$BUILDER_NAME" --keep-storage 50GB --force

--- a/services/nemo/build/.dockerignore
+++ b/services/nemo/build/.dockerignore
@@ -1,9 +1,23 @@
 
 build_images.sh
 
-uv.lock
-
 Dockerfile
 *.Dockerfile
 
+logs
 *.log
+
+
+.git
+
+**/__pycache__/
+**/*.egg-info/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/
+**/.ruff_cache/
+**/.venv/
+
+backend/**/dist/
+
+**/node_modules/

--- a/services/nemo/build/build_images.sh
+++ b/services/nemo/build/build_images.sh
@@ -17,14 +17,44 @@ DOCKER="docker buildx"
 #DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
 LOG_DIR=../../../logs
+CACHE_DIR=../../../.buildkit-cache
 
 mkdir -p $LOG_DIR
+
+#
+# Setup optimized BuildKit builder with GC
+#
+BUILDER_NAME="answers-optimized-builder"
+if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+    echo "Creating optimized builder: $BUILDER_NAME"
+    docker buildx create --name "$BUILDER_NAME" \
+        --driver docker-container \
+        --driver-opt default-load=true \
+        --buildkitd-flags '--oci-worker-gc=true --oci-worker-gc-keepstorage=50000000000' \
+        --bootstrap
+fi
+
+# Use the optimized builder
+docker buildx use "$BUILDER_NAME"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$CACHE_DIR"
+
+# Cache configuration for all builds
+CACHE_OPTS="--cache-from type=local,src=$CACHE_DIR --cache-to type=local,dest=$CACHE_DIR,mode=max"
 
 $DOCKER build \
   --file Dockerfile \
   ${DOCKER_BUILD_OPTS} \
+  $CACHE_OPTS \
   --build-context config-dir=../config \
   --tag localhost/localhost/nemo-guardrails:latest \
   --progress plain \
   . 2>&1 \
 | tee $LOG_DIR/build-nemo.log
+
+#
+# Clean up old cache (keep last 50GB)
+#
+echo "Pruning old build cache..."
+docker buildx prune --builder "$BUILDER_NAME" --keep-storage 50GB --force

--- a/services/webui-server/build/.dockerignore
+++ b/services/webui-server/build/.dockerignore
@@ -4,4 +4,20 @@ build_images.sh
 Dockerfile
 *.Dockerfile
 
+logs
 *.log
+
+
+.git
+
+**/__pycache__/
+**/*.egg-info/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/
+**/.ruff_cache/
+**/.venv/
+
+backend/**/dist/
+
+**/node_modules/

--- a/services/webui-server/build/build_images.sh
+++ b/services/webui-server/build/build_images.sh
@@ -20,11 +20,35 @@ DOCKER="docker buildx"
 # DOCKER_BUILD_OPTS="--no-cache"
 DOCKER_BUILD_OPTS=
 LOG_DIR=../../../logs
+CACHE_DIR=../../../.buildkit-cache
 
 mkdir -p $LOG_DIR
 
+#
+# Setup optimized BuildKit builder with GC
+#
+BUILDER_NAME="answers-optimized-builder"
+if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+    echo "Creating optimized builder: $BUILDER_NAME"
+    docker buildx create --name "$BUILDER_NAME" \
+        --driver docker-container \
+        --driver-opt default-load=true \
+        --buildkitd-flags '--oci-worker-gc=true --oci-worker-gc-keepstorage=50000000000' \
+        --bootstrap
+fi
+
+# Use the optimized builder
+docker buildx use "$BUILDER_NAME"
+
+# Create cache directory if it doesn't exist
+mkdir -p "$CACHE_DIR"
+
+# Cache configuration for all builds
+CACHE_OPTS="--cache-from type=local,src=$CACHE_DIR --cache-to type=local,dest=$CACHE_DIR,mode=max"
+
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config/ \
   --build-context dependency-gate-dir=../../dependency-gate \
@@ -37,6 +61,7 @@ $DOCKER build \
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config/ \
   --build-context dependency-gate-dir=../../dependency-gate \
@@ -49,6 +74,7 @@ $DOCKER build \
 
 $DOCKER build \
   $DOCKER_BUILD_OPTS \
+  $CACHE_OPTS \
   --file Dockerfile \
   --build-context config-dir=../config/ \
   --build-context dependency-gate-dir=../../dependency-gate \
@@ -58,3 +84,9 @@ $DOCKER build \
   --progress plain \
   . 2>&1 \
 | tee $LOG_DIR/build-frontend-test-xvfb.log
+
+#
+# Clean up old cache (keep last 50GB)
+#
+echo "Pruning old build cache..."
+docker buildx prune --builder "$BUILDER_NAME" --keep-storage 50GB --force

--- a/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -45,9 +45,11 @@ if [ "${USE_FUSE_SRC_DIR:-false}" = "true" ]; then
     echo "Mount node_modules active."
 fi
 
-# Transition to the non-privileged entrypoint
-
+# Change directory. If we are mount file-systems, then this operation must
+# wait until after the mounts are ready.
+#
 cd /app/frontend
 
+# Transition to the non-privileged entrypoint
 
 exec "$@"


### PR DESCRIPTION
Applies some optimizations to the docker build to increase its speed.

One optimization is to export only the final image and not the intermediate steps. This reduces the time spent in export.

Another optimization is to automatically prune the builder's cache. Small caches run faster.