### PR TITLE
use better health check

### DIFF
--- a/backend/apps/core_app/src/core_app/main.py
+++ b/backend/apps/core_app/src/core_app/main.py
@@ -2,6 +2,7 @@ import logging
 # Standard Library
 # ...
 import os
+from pathlib import Path
 
 # Configure MLFlow to use the global OTel TracerProvider (from our Distro)
 os.environ['MLFLOW_USE_DEFAULT_TRACER_PROVIDER'] = 'false'
@@ -15,11 +16,13 @@ from core_telemetry_distro.verifier import verify_distro
 from fastapi import FastAPI
 from log_config_monitor import get_logging_conf_monitor
 
-from .middlewares import ErrorLoggingMiddleware
+from .middlewares import ErrorLoggingMiddleware, HealthCheckMiddleware
 from .middlewares.dynamic_root_path import DynamicRootPathMiddleware
 from .routers import admin, answer, document_sets, documents, health, prompt_versions, prompts, status, tasks
 
 logger = logging.getLogger(__name__)
+
+_READY_FILE = Path(os.environ.get('HEALTHCHECK_READY_FILE', '/tmp/app-ready'))
 
 
 @asynccontextmanager
@@ -42,7 +45,16 @@ async def lifespan(fastapi_app: FastAPI):
     configure_sender(is_worker=False)
     await send_start_up()
 
+    # Signal readiness so the two-phase Docker health check can switch
+    # from the passive "exit 0" phase to an active HTTP probe.
+    _READY_FILE.touch()
+    logger.info('Readiness sentinel written to %s', _READY_FILE)
+
     yield
+
+    # Clean up sentinel so a container restart goes back to phase-1.
+    _READY_FILE.unlink(missing_ok=True)
+    logger.info('Readiness sentinel removed')
 
     logger.info('Logging config watcher stopping')
     get_logging_conf_monitor().stop()
@@ -52,6 +64,7 @@ app = FastAPI(lifespan=lifespan, title='Seeking Answers', version='1.0.0')
 
 app.add_middleware(DynamicRootPathMiddleware)
 app.add_middleware(ErrorLoggingMiddleware)
+app.add_middleware(HealthCheckMiddleware)
 
 app.include_router(router=admin.router, prefix='/admin')
 app.include_router(router=answer.router, prefix='/answer')

--- a/backend/apps/core_app/src/core_app/middlewares/__init__.py
+++ b/backend/apps/core_app/src/core_app/middlewares/__init__.py
@@ -1,4 +1,5 @@
 from .error_logger import ErrorLoggingMiddleware
+from .health_check import HealthCheckMiddleware
 
 # Explicitly define the exported names: these names are the contract of this module.
-__all__ = ['ErrorLoggingMiddleware']
+__all__ = ['ErrorLoggingMiddleware', 'HealthCheckMiddleware']

--- a/backend/apps/core_app/src/core_app/middlewares/health_check.py
+++ b/backend/apps/core_app/src/core_app/middlewares/health_check.py
@@ -1,0 +1,46 @@
+"""
+Middleware that detects the ``X-Health-Check`` HTTP request header,
+annotates the current OpenTelemetry span, and mirrors the header back on the
+response so that the caller can confirm the annotation was applied.
+"""
+
+import logging
+
+from fastapi import Request
+from opentelemetry import trace
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_HEADER = 'X-Health-Check'
+HEALTH_CHECK_SPAN_ATTRIBUTE = 'health_check'
+
+
+class HealthCheckMiddleware(BaseHTTPMiddleware):
+    """Detect *X-Health-Check* header, tag the OTel span, and echo the header on the response."""
+
+    def __init__(self, app: ASGIApp):
+        """Initialise the health-check middleware with the ASGI application."""
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        """
+        Intercept every HTTP request.
+
+        If the ``X-Health-Check`` header is present the current span is tagged
+        with ``health_check = true`` and the same header is set on the response.
+        """
+        is_health_check = request.headers.get(HEALTH_CHECK_HEADER)
+
+        if is_health_check:
+            span = trace.get_current_span()
+            if span and span.is_recording():
+                span.set_attribute(HEALTH_CHECK_SPAN_ATTRIBUTE, True)
+
+        response = await call_next(request)
+
+        if is_health_check:
+            response.headers[HEALTH_CHECK_HEADER] = 'true'
+
+        return response

--- a/backend/apps/core_worker/src/core_worker/health_server.py
+++ b/backend/apps/core_worker/src/core_worker/health_server.py
@@ -1,0 +1,74 @@
+"""
+Lightweight HTTP health-check server for the Celery worker.
+
+Celery workers do not expose an HTTP endpoint.  This module starts a tiny
+``http.server`` in a daemon thread so that Docker health checks can reach
+the worker via ``curl``.
+
+The handler recognises the ``X-Health-Check`` header, tags the current
+OpenTelemetry span (if one is active), and mirrors the header back on
+the response — matching the behaviour of the FastAPI
+:class:`HealthCheckMiddleware`.
+"""
+
+import http.server
+import logging
+import threading
+
+from opentelemetry import trace
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_HEADER = 'X-Health-Check'
+HEALTH_CHECK_SPAN_ATTRIBUTE = 'health_check'
+
+_server: http.server.HTTPServer | None = None
+
+
+class _HealthHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal request handler that always returns ``200 OK``."""
+
+    def do_GET(self):  # noqa: N802 — must match http.server API
+        is_health_check = self.headers.get(HEALTH_CHECK_HEADER)
+        if is_health_check:
+            span = trace.get_current_span()
+            if span and span.is_recording():
+                span.set_attribute(HEALTH_CHECK_SPAN_ATTRIBUTE, True)
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        if is_health_check:
+            self.send_header(HEALTH_CHECK_HEADER, 'true')
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    # Silence per-request log lines that would pollute celery output.
+    def log_message(self, format, *args):  # noqa: A002
+        pass
+
+
+def start(port: int = 8101) -> None:
+    """Start the health-check HTTP server on *port* in a daemon thread."""
+    global _server  # noqa: PLW0603
+    if _server is not None:
+        return
+    try:
+        _server = http.server.HTTPServer(('0.0.0.0', port), _HealthHandler)
+        thread = threading.Thread(
+            target=_server.serve_forever,
+            daemon=True,
+            name='healthcheck-server',
+        )
+        thread.start()
+        logger.info('Health-check server started on port %d', port)
+    except Exception:
+        logger.exception('Failed to start health-check server on port %d', port)
+
+
+def stop() -> None:
+    """Shut down the health-check HTTP server (if running)."""
+    global _server  # noqa: PLW0603
+    if _server is not None:
+        _server.shutdown()
+        _server = None
+        logger.info('Health-check server stopped')

--- a/backend/apps/core_worker/src/core_worker/signal_handlers.py
+++ b/backend/apps/core_worker/src/core_worker/signal_handlers.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+from pathlib import Path
 
 from celery.app.log import TaskFormatter
 from celery.signals import (
@@ -15,9 +17,12 @@ from core_telemetry_distro.verifier import verify_distro
 from early_init.load_otel import load_custom_configurator_by_entry_point, load_custom_distro_by_entry_point
 from log_config_monitor import get_logging_conf_monitor
 
+from . import health_server
 from .metrics import child_exit, start_metrics
 
 logger = logging.getLogger(__name__)
+
+_READY_FILE = Path(os.environ.get('HEALTHCHECK_READY_FILE', '/tmp/app-ready'))
 
 
 @after_setup_task_logger.connect
@@ -59,10 +64,16 @@ def handle_worker_ready(**_kwargs):
     """
     Handles worker ready signal.
 
-    Called when the worker is ready to receive tasks. Logs the worker ready status for monitoring
-    purposes.
+    Called when the worker is ready to receive tasks. Starts a lightweight HTTP
+    health-check server and writes the readiness sentinel so that the two-phase
+    Docker health check can switch to an active HTTP probe.
     """
     logger.info('worker ready')
+
+    health_server.start()
+
+    _READY_FILE.touch()
+    logger.info('Readiness sentinel written to %s', _READY_FILE)
 
 
 @worker_process_init.connect
@@ -92,10 +103,16 @@ def handle_worker_shutting_down(sig, how, exitcode, **_kwargs):
     """
     Handle worker shutdown signal.
 
-    Called when the main worker is shutting down. Stops the logging configuration monitor and logs
-    shutdown details including signal, method, and exit code.
+    Called when the main worker is shutting down. Stops the health-check server,
+    removes the readiness sentinel, stops the logging configuration monitor, and
+    logs shutdown details including signal, method, and exit code.
     """
     logger.info('worker process shutting down %s %s %s', sig, how, exitcode)
+
+    health_server.stop()
+
+    _READY_FILE.unlink(missing_ok=True)
+    logger.info('Readiness sentinel removed')
 
     get_logging_conf_monitor().stop()
 

--- a/ops/jobs/helpers.py
+++ b/ops/jobs/helpers.py
@@ -276,7 +276,7 @@ def _stop_services(context, services: List[str]) -> None:
 def _stop_all_services(context) -> None:
     """Stop and remove all Docker Compose services, networks, and orphans."""
     env = context.resources.compose_env.env
-    cmd = ["docker", "compose", "down", "--remove-orphans"]
+    cmd = ["docker", "compose", "--profile", "all", "down", "--remove-orphans"]
     result = _run_subprocess(cmd, env, cwd=str(SERVICES_ROOT))
     context.log.info("docker compose down (exit=%s)", result.returncode)
 

--- a/services/api-server/config/healthcheck.sh
+++ b/services/api-server/config/healthcheck.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# healthcheck.sh — Two-phase Docker health check
+#
+# Phase 1 (startup / sync):
+#   The sentinel file does not yet exist.  The container is still installing
+#   dependencies or starting the application.  We return exit 0 so that
+#   Docker does not mark the container as unhealthy during normal startup.
+#
+# Phase 2 (application running):
+#   Once the application signals readiness by creating the sentinel file,
+#   we perform an HTTP health check with the X-Health-Check header.
+#   If no HEALTHCHECK_URL is configured, the sentinel file alone is
+#   sufficient proof of health.
+#
+# Environment variables (set in the compose service):
+#   HEALTHCHECK_URL        — URL to curl  (e.g. http://127.0.0.1:8100/status)
+#   HEALTHCHECK_READY_FILE — Path to sentinel file  (default: /tmp/app-ready)
+# ---------------------------------------------------------------------------
+
+READY_FILE="${HEALTHCHECK_READY_FILE:-/tmp/app-ready}"
+HEALTH_URL="${HEALTHCHECK_URL:-}"
+
+# Phase 1: If the application has not signalled readiness, assume it is still
+# syncing workspaces / installing packages.
+if [ ! -f "$READY_FILE" ]; then
+    exit 0
+fi
+
+# Phase 2: Application is ready — perform a real health check.
+if [ -n "$HEALTH_URL" ]; then
+    exec curl -sf -H 'X-Health-Check: true' "$HEALTH_URL"
+fi
+
+# No URL configured but sentinel exists — healthy.
+exit 0

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -37,6 +37,7 @@ services:
     environment:
       DEBUGGER_LISTEN: true
       JWT_WRITE_CLAIM_MISSING_OK: true
+      HEALTHCHECK_URL: 'http://127.0.0.1:8100/status'
       # Only environment variables that are important to a Docker environment
       # will be configured here. The reason is that changes to environment variables
       # configured here do require a restart before they take effect:
@@ -60,6 +61,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       - ../config/run_api_server.sh:/run_api_server.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
@@ -92,14 +94,12 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the FastAPI server
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
-      #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing, the sentinel
+      #   file does not exist and the script returns exit 0.
+      #   Phase 2 — Once the FastAPI lifespan writes /tmp/app-ready the
+      #   script curls the existing lightweight /status endpoint.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       DEBUGGER_LISTEN: true
       JWT_WRITE_CLAIM_MISSING_OK: true
+      HEALTHCHECK_URL: 'http://127.0.0.1:8100/status'
       # Only environment variables that are important to a Docker environment
       # will be configured here. The reason is that changes to environment variables
       # configured here do require a restart before they take effect:
@@ -25,6 +26,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       - ../config/run_api_server.sh:/run_api_server.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh
       - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
@@ -55,15 +57,13 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service starts for the first time, it may take several minutes to sync
-      # the python environment and start the FastAPI server. A healthcheck based on
-      # API pinging would fail during this period.
-      #
-      # For now, we verify that python3 is executable.
-      # Note: If switching to an API-based check, use http://127.0.0.1 to avoid
-      # IPv6 resolution issues with 'localhost'.
-      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing and before the
+      #   FastAPI server starts, the sentinel file does not exist and the
+      #   script returns exit 0 (container alive, not yet ready).
+      #   Phase 2 — Once the FastAPI lifespan writes /tmp/app-ready the
+      #   script curls the existing lightweight /status endpoint.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5

--- a/services/celery-worker/config/healthcheck.sh
+++ b/services/celery-worker/config/healthcheck.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# healthcheck.sh — Two-phase Docker health check
+#
+# Phase 1 (startup / sync):
+#   The sentinel file does not yet exist.  The container is still installing
+#   dependencies or starting the application.  We return exit 0 so that
+#   Docker does not mark the container as unhealthy during normal startup.
+#
+# Phase 2 (application running):
+#   Once the application signals readiness by creating the sentinel file,
+#   we perform an HTTP health check with the X-Health-Check header.
+#   If no HEALTHCHECK_URL is configured, the sentinel file alone is
+#   sufficient proof of health.
+#
+# Environment variables (set in the compose service):
+#   HEALTHCHECK_URL        — URL to curl  (e.g. http://127.0.0.1:8100/status)
+#   HEALTHCHECK_READY_FILE — Path to sentinel file  (default: /tmp/app-ready)
+# ---------------------------------------------------------------------------
+
+READY_FILE="${HEALTHCHECK_READY_FILE:-/tmp/app-ready}"
+HEALTH_URL="${HEALTHCHECK_URL:-}"
+
+# Phase 1: If the application has not signalled readiness, assume it is still
+# syncing workspaces / installing packages.
+if [ ! -f "$READY_FILE" ]; then
+    exit 0
+fi
+
+# Phase 2: Application is ready — perform a real health check.
+if [ -n "$HEALTH_URL" ]; then
+    exec curl -sf -H 'X-Health-Check: true' "$HEALTH_URL"
+fi
+
+# No URL configured but sentinel exists — healthy.
+exit 0

--- a/services/celery-worker/config/run_celery_flower.sh
+++ b/services/celery-worker/config/run_celery_flower.sh
@@ -56,6 +56,10 @@ if [ -z "${WATCH_DEBOUNCE_SECS:-}" ]; then
     WATCH_DEBOUNCE_SECS=5.0
 fi
 
+# Signal readiness for the two-phase Docker health check.
+# At this point the Python environment is fully synced.
+touch "${HEALTHCHECK_READY_FILE:-/tmp/app-ready}"
+
 uv run --frozen --no-sync \
    -- \
    watchmedo auto-restart \

--- a/services/celery-worker/deploy/common-autotest.compose.yml
+++ b/services/celery-worker/deploy/common-autotest.compose.yml
@@ -8,6 +8,7 @@ services:
 
     environment:
       DEBUGGER_LISTEN: true
+      HEALTHCHECK_URL: 'http://127.0.0.1:8101/status'
       # Only environment variables that are important to a Docker environment
       # will be configured here. The reason is that changes to environment variables
       # configured here do require a restart before they take effect:
@@ -33,6 +34,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       ##SRC - ../build/run_celery_worker.sh:/run_celery_worker.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ./custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
@@ -67,14 +69,12 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the celery worker
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
-      #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing, the sentinel
+      #   file does not exist and the script returns exit 0.
+      #   Phase 2 — Once the Celery worker_ready signal fires it starts a
+      #   tiny HTTP health server on port 8101 and writes /tmp/app-ready.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5
@@ -93,6 +93,7 @@ services:
 
 
       GPU_MODE: cpu
+      HEALTHCHECK_URL: 'http://127.0.0.1:5555/'
       USE_CODEBASE_SYNC: true
       USE_BOOTSTRAP_INSTALL: true
       ENABLE_SSHD: true
@@ -107,6 +108,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       ##SRC - ../build/run_celery_flower.sh:/run_celery_flower.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-autotest-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh:ro
       ##SRC - ../build/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
@@ -133,14 +135,12 @@ services:
     command: [ '/run_celery_flower.sh' ]
 
     healthcheck:
-      # When this service start for the first time, there is multiple minutes while the
-      # python environment is sync'ed to the requirements file then when the celery flower node
-      # is starting up. A health-check based on API pinging will fail during the sync and the
-      # start up.
-      #
-      # For now, we just check if python3 can run. Later, we will  try to come up  
-      ## test: ['CMD', 'curl', '-f', 'http://localhost']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing, the sentinel
+      #   file does not exist and the script returns exit 0.
+      #   Phase 2 — Once the run script writes /tmp/app-ready and Flower
+      #   starts, the script curls Flower's root endpoint.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5

--- a/services/celery-worker/deploy/common.compose.yml
+++ b/services/celery-worker/deploy/common.compose.yml
@@ -6,6 +6,7 @@ services:
 
     environment:
       DEBUGGER_LISTEN: true
+      HEALTHCHECK_URL: 'http://127.0.0.1:8101/status'
       # Only environment variables that are important to a Docker environment
       # will be configured here. The reason is that changes to environment variables
       # configured here do require a restart before they take effect:
@@ -26,6 +27,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       ##SRC - ../build/run_celery_worker.sh:/run_celery_worker.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-init-signal-1:/init-signal
       ##SRC - ../build/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh
@@ -56,15 +58,13 @@ services:
               capabilities: [gpu]
 
     healthcheck:
-      # When this service starts for the first time, it may take several minutes to sync
-      # the python environment and start the service. A healthcheck based on
-      # pinging would fail during this period.
-      #
-      # For now, we verify that python3 is executable.
-      # Note: If switching to a network-based check, use http://127.0.0.1 to avoid
-      # IPv6 resolution issues with 'localhost'.
-      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing, the sentinel
+      #   file does not exist and the script returns exit 0.
+      #   Phase 2 — Once the Celery worker_ready signal fires it starts a
+      #   tiny HTTP health server on port 8101 and writes /tmp/app-ready.
+      #   The script then curls that endpoint.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5
@@ -82,7 +82,7 @@ services:
       # configured here do require a restart before they take effect:
       # application-centric ones should be designed to avoiid a Docker container restart.
 
-
+      HEALTHCHECK_URL: 'http://127.0.0.1:5555/'
       GPU_MODE: cpu
     env_file:
       - backend.env
@@ -96,6 +96,7 @@ services:
       # Mount important scripts into the container when we are
       # avoiding rebuilding images to capture their latest version.
       ##SRC - ../build/run_celery_flower.sh:/run_celery_flower.sh:ro
+      - ../config/healthcheck.sh:/healthcheck.sh:ro
       - backend-init-signal-1:/init-signal
       ##SRC - ../../dependency-gate/wait_for_gate.sh:/wait_for_gate.sh
       ##SRC - ../build/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
@@ -117,15 +118,12 @@ services:
     command: [ '/run_celery_flower.sh' ]
 
     healthcheck:
-      # When this service starts for the first time, it may take several minutes to sync
-      # the python environment and start the service. A healthcheck based on
-      # pinging would fail during this period.
-      #
-      # For now, we verify that python3 is executable.
-      # Note: If switching to a network-based check, use http://127.0.0.1 to avoid
-      # IPv6 resolution issues with 'localhost'.
-      ## test: ['CMD', 'curl', '-f', 'http://127.0.0.1']
-      test: ['CMD', 'python3', '--version']
+      # Two-phase health check:
+      #   Phase 1 — While the Python environment is syncing, the sentinel
+      #   file does not exist and the script returns exit 0.
+      #   Phase 2 — Once the run script writes /tmp/app-ready and Flower
+      #   starts, the script curls Flower's root endpoint.
+      test: ['CMD', 'bash', '/healthcheck.sh']
       interval: 30s
       timeout: 15s
       retries: 5

--- a/services/nemo/config/custom-docker-entrypoint.sh
+++ b/services/nemo/config/custom-docker-entrypoint.sh
@@ -19,4 +19,9 @@ uv add langchain-openai
 # Process with original entrypoint, which can be discovered
 # from the host command-line with:
 #   docker inspect nemoguardrails:latest | jq '.[0].Config.Entrypoint'
+
+# Signal readiness for the two-phase Docker health check.
+# At this point all pip installs are complete.
+touch "${HEALTHCHECK_READY_FILE:-/tmp/app-ready}"
+
 exec uv run opentelemetry-instrument nemoguardrails "$@"

--- a/services/nemo/config/healthcheck.sh
+++ b/services/nemo/config/healthcheck.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# healthcheck.sh — Two-phase Docker health check
+#
+# Phase 1 (startup / sync):
+#   The sentinel file does not yet exist.  The container is still installing
+#   dependencies or starting the application.  We return exit 0 so that
+#   Docker does not mark the container as unhealthy during normal startup.
+#
+# Phase 2 (application running):
+#   Once the application signals readiness by creating the sentinel file,
+#   we perform an HTTP health check with the X-Health-Check header.
+#   If no HEALTHCHECK_URL is configured, the sentinel file alone is
+#   sufficient proof of health.
+#
+# Environment variables (set in the compose service):
+#   HEALTHCHECK_URL        — URL to curl  (e.g. http://127.0.0.1:8000/)
+#   HEALTHCHECK_READY_FILE — Path to sentinel file  (default: /tmp/app-ready)
+# ---------------------------------------------------------------------------
+
+READY_FILE="${HEALTHCHECK_READY_FILE:-/tmp/app-ready}"
+HEALTH_URL="${HEALTHCHECK_URL:-}"
+
+# Phase 1: If the application has not signalled readiness, assume it is still
+# syncing workspaces / installing packages.
+if [ ! -f "$READY_FILE" ]; then
+    exit 0
+fi
+
+# Phase 2: Application is ready — perform a real health check.
+if [ -n "$HEALTH_URL" ]; then
+    exec curl -sf -H 'X-Health-Check: true' "$HEALTH_URL"
+fi
+
+# No URL configured but sentinel exists — healthy.
+exit 0

--- a/services/nemo/deploy/compose.yml
+++ b/services/nemo/deploy/compose.yml
@@ -10,12 +10,15 @@ services:
         env_file:
             - nemo.env
             - opentelemetry-instrument.env
+        environment:
+            HEALTHCHECK_URL: 'http://127.0.0.1:8000/'
         ports:
             - '27500:8000'
         networks:
             - agent-poc
         volumes:
             - ../../dist:/dist:ro
+            - ../config/healthcheck.sh:/healthcheck.sh:ro
             ##SRC - ../config/config:/config:ro
             ##SRC - ../config/custom-docker-entrypoint.sh:/custom-docker-entrypoint.sh:ro
             ##SRC - ../config/docker/pyproject.toml:/app/pyproject.toml
@@ -28,10 +31,14 @@ services:
         command: [ "server", "--config=/config" ]
 
         healthcheck:
-            # Use the IPv4 loopback address. When 'localhost' is used, curl will try to use
-            # the IPv6 ::1 address where there is no listening port.
-            test: [ 'CMD', 'curl', '-f', 'http://127.0.0.1:8000/' ]
+            # Two-phase health check:
+            #   Phase 1 — While packages are being installed in the entrypoint,
+            #   the sentinel file does not exist and the script returns exit 0.
+            #   Phase 2 — Once the entrypoint writes /tmp/app-ready and the
+            #   NeMo Guardrails server starts, the script curls the root endpoint
+            #   with the X-Health-Check header to tag the OTel span.
+            test: [ 'CMD', 'bash', '/healthcheck.sh' ]
             interval: 30s
             timeout: 5s
             retries: 5
-            start_period: 5s
+            start_period: 30s


### PR DESCRIPTION
The docker compose health-checks are improved. They return exit 0 only before the api-server or celery-worker or celery-flower or nemo has started running. Once running, the actual health/status endpoint is probed by curl.