### PR TITLE
fixed high cpu consumption by metagen

### DIFF
--- a/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/api-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -6,7 +6,7 @@ set -eu
 mkdir -p /app/backend
 cd /app/backend
 
-if [ "${USE_CODEBASE_SYNC:-false}" = "true" ]; then
+if [ "${ENABLE_MUTAGEN_SYNC:-false}" = "true" ]; then
 
     MUTAGEN_SYNC_FILE="/app/backend/.mutagen-sync-id"
 

--- a/services/api-server/config/mount_helper.sh
+++ b/services/api-server/config/mount_helper.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Mutagen sync does not require mount helpers. This script is kept for compatibility.
-if [ "${USE_CODEBASE_SYNC:-false}" != "true" ]; then
+if [ "${ENABLE_MUTAGEN_SYNC:-false}" != "true" ]; then
     echo "Codebase sync not enabled. Helper exiting."
     exit 0
 fi

--- a/services/api-server/deploy/common-autotest.compose.yml
+++ b/services/api-server/deploy/common-autotest.compose.yml
@@ -48,9 +48,9 @@ services:
       ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
       ##
       ##
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
       PYTHONPYCACHEPREFIX: /home/python/.pycache
     env_file:
       - automated-test.env
@@ -131,9 +131,9 @@ services:
       ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
       ##
       ##
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
       PYTHONPYCACHEPREFIX: /home/python/.pycache
       APP_AUTORESTART: 'false'
     env_file:

--- a/services/api-server/deploy/common.compose.yml
+++ b/services/api-server/deploy/common.compose.yml
@@ -87,7 +87,7 @@ services:
       ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
       ##
       GPU_MODE: cpu
-      USE_CODEBASE_SYNC: false
+      ENABLE_MUTAGEN_SYNC: false
       USE_BOOTSTRAP_INSTALL: false
       #
       PYTHONPYCACHEPREFIX: /home/python/.pycache

--- a/services/celery-worker/deploy/common-autotest.compose.yml
+++ b/services/celery-worker/deploy/common-autotest.compose.yml
@@ -19,9 +19,9 @@ services:
       ## Override YML is responsible for setting GPU_MODE to 'cuda12' or 'cpu'
       ##
       ##
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
       PYTHONPYCACHEPREFIX: /home/python/.pycache
     env_file:
       - automated-test.env
@@ -94,9 +94,9 @@ services:
 
       GPU_MODE: cpu
       HEALTHCHECK_URL: 'http://127.0.0.1:5555/'
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
       PYTHONPYCACHEPREFIX: /home/python/.pycache
     env_file:
       - automated-test.env

--- a/services/file-sync/config/custom-docker-entrypoint.sh
+++ b/services/file-sync/config/custom-docker-entrypoint.sh
@@ -33,6 +33,10 @@ EOF
 main() {
     setup_ssh_config
 
+    # Terminate any stale mutagen sessions from previous runs
+    echo "Cleaning up stale mutagen sessions..."
+    mutagen sync terminate --all 2>/dev/null || true
+
     echo "Starting supervisord..."
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 }

--- a/services/file-sync/config/monitor_mutagen_sync.sh
+++ b/services/file-sync/config/monitor_mutagen_sync.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Continuously monitor for new autotest containers and create sync sessions
+LOCK_FILE="/tmp/mutagen-sync-monitor.lock"
 
 echo "Starting mutagen sync monitor..."
 
 while true; do
-    # Run sync creation script which will detect and create sessions for new containers
-    if [ -f /start_mutagen_sync.sh ]; then
-        bash /start_mutagen_sync.sh 2>&1 | grep -v "already exists" || true
+    # Short-circuit: skip if no autotest/automated-test containers are running
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qE '(autotest|automated-)'; then
+        # Use flock to prevent overlapping runs
+        (
+            flock -n 9 || { echo "Sync already in progress, skipping"; exit 0; }
+            bash /start_mutagen_sync.sh 2>&1 || true
+        ) 9>"$LOCK_FILE"
     fi
-    
-    # Check every 5 seconds for new containers
-    sleep 5
+
+    sleep 30
 done

--- a/services/file-sync/config/start_mutagen_sync.sh
+++ b/services/file-sync/config/start_mutagen_sync.sh
@@ -58,12 +58,7 @@ create_session() {
     local source="$2"
     local dest="$3"
 
-    set +e
-    mutagen sync list 2>/dev/null | grep -q "Name: ${name}"
-    local exists=$?
-    set -e
-
-    if [ "$exists" -eq 0 ]; then
+    if mutagen sync list "${name}" >/dev/null 2>&1; then
         echo "Mutagen session already exists: ${name}"
         return
     fi
@@ -72,10 +67,18 @@ create_session() {
     mutagen sync create \
         --name "${name}" \
         --mode "${MUTAGEN_SYNC_MODE}" \
-        --no-ignore-vcs \
         --ignore ".venv" \
         --ignore "node_modules" \
         --ignore ".git" \
+        --ignore "__pycache__" \
+        --ignore "*.pyc" \
+        --ignore ".ruff_cache" \
+        --ignore ".pytest_cache" \
+        --ignore ".coverage" \
+        --ignore ".mypy_cache" \
+        --ignore "*.egg-info" \
+        --ignore "dist" \
+        --ignore "build" \
         "${source}" \
         "${dest}"
 }

--- a/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
+++ b/services/webui-server/config/custom-docker-entrypoint-nonpriv.sh
@@ -20,7 +20,7 @@ done
 
 
 # Only run if codebase sync is enabled
-if [ "${USE_CODEBASE_SYNC:-false}" = "true" ]; then
+if [ "${ENABLE_MUTAGEN_SYNC:-false}" = "true" ]; then
 
     MUTAGEN_SYNC_FILE="/app/frontend/.mutagen-sync-id"
     echo "Waiting for codebase sync... (looking for $MUTAGEN_SYNC_FILE)"

--- a/services/webui-server/config/webui_mount_helper.sh
+++ b/services/webui-server/config/webui_mount_helper.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Mutagen sync does not require mount helpers. This script is kept for compatibility.
-if [ "${USE_CODEBASE_SYNC:-false}" != "true" ]; then
+if [ "${ENABLE_MUTAGEN_SYNC:-false}" != "true" ]; then
     echo "Codebase sync not enabled. Helper exiting."
     exit 0
 fi

--- a/services/webui-server/deploy/compose-autotest.yml
+++ b/services/webui-server/deploy/compose-autotest.yml
@@ -10,9 +10,9 @@ services:
       # will be configured here. All other environment variables are extracted
       # to .env files for easier and more isolated management.
       CHOKIDAR_USEPOLLING: 'true'
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
     #   - NODE_ENV=production
     ## Do not expose 5173 ... To prevent XSS (cross site scripting) usage, we want all
     ## traffic to go thru the reserve-proxy server at 15173.
@@ -48,9 +48,9 @@ services:
       # will be configured here. All other environment variables are extracted
       # to .env files for easier and more isolated management.
       CHOKIDAR_USEPOLLING: 'true'
-      USE_CODEBASE_SYNC: true
-      USE_BOOTSTRAP_INSTALL: true
-      ENABLE_SSHD: true
+      ENABLE_MUTAGEN_SYNC: 'true'
+      USE_BOOTSTRAP_INSTALL: 'true'
+      ENABLE_SSHD: 'true'
       APP_AUTORESTART: 'false'
     #   - NODE_ENV=production
     ## Do not expose 5173 ... To prevent XSS (cross site scripting) usage, we want all


### PR DESCRIPTION
This PR fixes a bug that the file-sync service was leaking mutagen sync sessions.

At one point, we captured 392 duplicate mutagen sync sessions inside agent-file-sync-1 — 152 × backend-api-server-autotest, 142 × backend-celery-worker-autotest, 98 × frontend-webui-server-autotest. The file-sync container container is consuming 2 GB RAM and 451 PIDs just to service these zombie sessions.

The fix is a better detection of the existing sessions. Additionally, there are changes to help close some gaps on zombie sessions.